### PR TITLE
Update to wdlTools 0.8.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ logLevel in assembly := Level.Info
 assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
-val wdlToolsVersion = "0.8.3"
+val wdlToolsVersion = "0.8.4"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"

--- a/src/main/scala/dx/translator/wdl/WdlTranslator.scala
+++ b/src/main/scala/dx/translator/wdl/WdlTranslator.scala
@@ -205,6 +205,10 @@ case class WdlTranslatorFactory(regime: TypeCheckingRegime = TypeCheckingRegime.
         case ex: TypeException =>
           // the file could be parsed, so it is WDL, but it failed type checking
           throw ex
+        case ex: Throwable if language.isDefined =>
+          // the user specified the language, but the file could not be parsed with
+          // the specified parser
+          throw ex
         case _: Throwable =>
           // there was some other error, probably a SyntaxException, meaning the
           // file couldn't be parsed, so it's probably not WDL

--- a/src/test/resources/compiler/imports/lib.wdl
+++ b/src/test/resources/compiler/imports/lib.wdl
@@ -1,0 +1,13 @@
+version 1.0
+
+task bar {
+  input {}
+
+  command <<<
+  echo "hello"
+  >>>
+
+  output {
+    String s = "hello"
+  }
+}

--- a/src/test/resources/compiler/imports/subworkflow.wdl
+++ b/src/test/resources/compiler/imports/subworkflow.wdl
@@ -1,0 +1,7 @@
+version 1.0
+
+import "lib.wdl"
+
+workflow foo {
+  call lib.bar
+}

--- a/src/test/resources/compiler/multi_import.wdl
+++ b/src/test/resources/compiler/multi_import.wdl
@@ -1,0 +1,9 @@
+version 1.0
+
+import "imports/subworkflow.wdl"
+import "imports/lib.wdl"
+
+workflow multi_import {
+  call subworkflow.foo
+  call lib.bar
+}

--- a/src/test/resources/compiler/optional_call_output.wdl
+++ b/src/test/resources/compiler/optional_call_output.wdl
@@ -1,0 +1,42 @@
+version 1.0
+
+workflow optional_call_output {
+  input {
+    Boolean makeCall = true
+    File defaultFile
+  }
+
+  call optional_output
+
+  if (makeCall) {
+    File result = select_first([optional_output.out, defaultFile])
+    call task2 {
+      input: f = result
+    }
+  }
+
+  output {
+    File? out = task2.fout
+  }
+}
+
+task optional_output {
+  command <<< >>>
+
+  output {
+    File? out = "foo.txt"
+  }
+}
+
+task task2 {
+  input {
+    File f
+  }
+
+  command <<<
+  >>>
+
+  output {
+    File fout = f
+  }
+}

--- a/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/src/test/scala/dx/compiler/CompilerTest.scala
@@ -957,6 +957,27 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     trainsOutputVector.outputVars.size shouldBe 1
   }
 
+  it should "compile workflow with task imported by multiple paths" taggedAs NativeTest in {
+    val path = pathFromBasename("compiler", basename = "multi_import.wdl")
+    val args = path.toString :: cFlags
+    val retval = Main.compile(args.toVector)
+    retval shouldBe a[Success]
+  }
+
+  it should "compile workflow with call to task having optional output" taggedAs NativeTest in {
+    val path = pathFromBasename("compiler", basename = "optional_call_output.wdl")
+    val args = path.toString :: cFlags
+    val retval = Main.compile(args.toVector)
+    retval shouldBe a[Success]
+  }
+
+  it should "compile myriad workflow" taggedAs NativeTest in {
+    val path = pathFromBasename("myriad", basename = "dts_batch.wdl")
+    val args = path.toString :: cFlags
+    val retval = Main.compile(args.toVector)
+    retval shouldBe a[Success]
+  }
+
   it should "Set job-reuse flag" taggedAs NativeTest in {
     val path = pathFromBasename("compiler", "add_timeout.wdl")
     val extrasContent =

--- a/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/src/test/scala/dx/compiler/CompilerTest.scala
@@ -971,13 +971,6 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     retval shouldBe a[Success]
   }
 
-  it should "compile myriad workflow" taggedAs NativeTest in {
-    val path = pathFromBasename("myriad", basename = "dts_batch.wdl")
-    val args = path.toString :: cFlags
-    val retval = Main.compile(args.toVector)
-    retval shouldBe a[Success]
-  }
-
   it should "Set job-reuse flag" taggedAs NativeTest in {
     val path = pathFromBasename("compiler", "add_timeout.wdl")
     val extrasContent =


### PR DESCRIPTION
This fixes issues compiling some complex workflows that were rendered incorrectly by the code generator.

Note: I have been unable to reduce the issues with the customer workflow to a simple reproducible test case. I have tested locally that the customer's workflow compiles but I do not want to add the customer's workflow as a test case.