### PR TITLE
APPS-249 Run integration tests from GHA

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,31 +1,34 @@
 name: Integration Test Workflow
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    types: [ labeled ]
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
 
 jobs:
-  build:
-    if: ${{ github.event.label.name == 'integration' }}
+  test:
     name: Integration Tests (Staging)
     runs-on: ubuntu-18.04
-
     steps:
       - name: Git checkout
-      - uses: actions/checkout@v2
-
+        uses: actions/checkout@v2
       - name: Install java
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
       - name: Install dxpy
         run: |
           sudo apt-get update
           sudo apt-get install -y apt-transport-https wget git openssh-server tree python3 python3-pip python3-venv
           pip3 install setuptools wheel
           pip3 install dxpy
-
       - name: Run tests
         env:
           AUTH_TOKEN: ${{ secrets.DX_STAGING_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: Integration Test Workflow
+name: WDL Integration Test Workflow
 
 on:
   push:
@@ -43,5 +43,6 @@ jobs:
 
           # run tests
           cd ${GITHUB_WORKSPACE}
-          pwd
-          python3 scripts/run_tests.py --test M
+          FOLDER=/builds/test_dxwdl_$(date +%s)_$RANDOM
+          dx mkdir $FOLDER
+          python3 scripts/run_tests.py --test M --clean --folder $FOLDER

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,11 +40,12 @@ jobs:
 
           # set up DNAnexus staging environment
           dx login --noprojects --staging --token $AUTH_TOKEN
-          dx select dxCompiler_playground
+          PROJECT=dxCompiler_playground
+          dx select $PROJECT
 
           # run tests
           cd ${GITHUB_WORKSPACE}
           FOLDER=/builds/test_gha_dxwdl_$(date +%s)_$RANDOM
           dx mkdir $FOLDER
-          python3 scripts/run_tests.py --test M --clean --folder $FOLDER
+          python3 scripts/run_tests.py --test M --clean --folder $FOLDER --project $PROJECT
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: WDL Integration Test Workflow
+name: WDL Integration Tests
 
 on:
   push:
@@ -43,6 +43,7 @@ jobs:
 
           # run tests
           cd ${GITHUB_WORKSPACE}
-          FOLDER=/builds/test_dxwdl_$(date +%s)_$RANDOM
+          FOLDER=/builds/test_gha_dxwdl_$(date +%s)_$RANDOM
           dx mkdir $FOLDER
           python3 scripts/run_tests.py --test M --clean --folder $FOLDER
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    name: Integration Tests (Staging)
+    name: WDL Integration Tests (Staging)
     runs-on: ubuntu-18.04
     steps:
       - name: Git checkout
@@ -42,4 +42,4 @@ jobs:
           # run tests
           cd ${GITHUB_WORKSPACE}
           pwd
-          ./scripts/run_tests.py --test M
+          python3 scripts/run_tests.py --test M

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,11 +24,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Install dxpy
+      - name: Install dxpy and other dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y apt-transport-https wget git openssh-server tree python3 python3-pip python3-venv
-          pip3 install setuptools wheel termcolor
+          pip3 install setuptools wheel
+          pip3 install termcolor
           pip3 install dxpy
       - name: Run tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y apt-transport-https wget git openssh-server tree python3 python3-pip python3-venv
-          pip3 install setuptools wheel
+          pip3 install setuptools wheel termcolor
           pip3 install dxpy
       - name: Run tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,42 @@
+name: Integration Test Workflow
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'integration' }}
+    name: Integration Tests (Staging)
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Git checkout
+      - uses: actions/checkout@v2
+
+      - name: Install java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Install dxpy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https wget git openssh-server tree python3 python3-pip python3-venv
+          pip3 install setuptools wheel
+          pip3 install dxpy
+
+      - name: Run tests
+        env:
+          AUTH_TOKEN: ${{ secrets.DX_STAGING_TOKEN }}
+        run: |
+          export PATH="$PATH:$HOME/.local/bin"
+
+          # set up DNAnexus staging environment
+          dx login --noprojects --staging --token $AUTH_TOKEN
+          dx select dxWDL_playground
+
+          # run tests
+          cd ${GITHUB_WORKSPACE}
+          pwd
+          ./scripts/run_tests.py --test M

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   test:
     name: WDL Integration Tests (Staging)
+    if: contains(github.event.pull_request.labels.*.name, 'integration')
     runs-on: ubuntu-18.04
     steps:
       - name: Git checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,7 @@ on:
       - opened
       - synchronize
       - ready_for_review
+      - labeled
 
 jobs:
   test:
@@ -39,7 +40,7 @@ jobs:
 
           # set up DNAnexus staging environment
           dx login --noprojects --staging --token $AUTH_TOKEN
-          dx select dxWDL_playground
+          dx select dxCompiler_playground
 
           # run tests
           cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -3,10 +3,10 @@ name: Unit Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 
 jobs:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,4 @@
-name: Unit Test Workflow
+name: Unit Tests
 
 on:
   push:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,4 @@
-name: Master Test Workflow
+name: Unit Test Workflow
 
 on:
   push:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -747,8 +747,7 @@ def main():
     else:
         # Use existing prebuilt base folder
         base_folder = args.folder
-        util.build_dir(project, base_folder + "/applets")
-        util.build_dir(project, base_folder + "/test")
+        util.build_subdirs(project, base_folder)
     applet_folder = base_folder + "/applets"
     test_folder = base_folder + "/test"
     print("project: {} ({})".format(project.name, project.get_id()))

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 from collections import namedtuple
 import dxpy

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -452,6 +452,7 @@ def run_test_subset(project, runnable, test_folder, debug_flag, delay_workspace_
     wait_for_completion(test_exec_objs)
 
     print("Verifying results")
+    failed = []
     for exec_obj in test_exec_objs:
         exec_desc = exec_obj.describe()
         tname = find_test_from_exec(exec_obj)
@@ -467,6 +468,13 @@ def run_test_subset(project, runnable, test_folder, debug_flag, delay_workspace_
             correct = validate_result(tname, exec_outputs, key, expected_val)
         if correct:
             print("Analysis {} passed".format(tname))
+        else:
+            failed.append(tname)
+
+    if failed:
+        print("Failed {} analyses:\n{}".format(len(failed),
+                                               "\n".join(failed)))
+        sys.exit(1)
 
 def print_test_list():
     l = [key for key in test_files.keys()]

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -806,7 +806,7 @@ def main():
             run_test_subset(project, runnable, test_folder, args.debug, args.delay_workspace_destruction)
     finally:
         if args.clean:
-            project.remove_folder(folder, recurse=True, force=True)
+            project.remove_folder(base_folder, recurse=True, force=True)
         print("Completed running tasks in {}".format(args.project))
 
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -703,6 +703,8 @@ def main():
                            action="store_true",
                            dest="test_list",
                            default=False)
+    argparser.add_argument("--clean", help="Remove build directory in the project after running tests",
+                           action="store_true", default=False)
     argparser.add_argument("--locked", help="Generate locked-down workflows",
                            action="store_true", default=False)
     argparser.add_argument("--project", help="DNAnexus project ID",
@@ -743,8 +745,10 @@ def main():
     if args.folder is None:
         base_folder = util.build_dirs(project, version_id)
     else:
-        # Use existing prebuilt folder
+        # Use existing prebuilt base folder
         base_folder = args.folder
+        util.build_dir(project, base_folder + "/applets")
+        util.build_dir(project, base_folder + "/test")
     applet_folder = base_folder + "/applets"
     test_folder = base_folder + "/test"
     print("project: {} ({})".format(project.name, project.get_id()))
@@ -802,7 +806,10 @@ def main():
         if not args.compile_only:
             run_test_subset(project, runnable, test_folder, args.debug, args.delay_workspace_destruction)
     finally:
+        if args.clean:
+            project.remove_folder(folder, recurse=True, force=True)
         print("Completed running tasks in {}".format(args.project))
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -42,6 +42,9 @@ def build_dirs(project, version_id):
     project.new_folder(applet_folder, parents=True)
     return base_folder
 
+def build_dir(project, folder)
+    project.new_folder(folder, parents=True)
+
 def get_project(project_name):
     '''Try to find the project with the given name or id.'''
 

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -32,18 +32,19 @@ def get_appl_conf_path(top_dir):
 def get_runtime_conf_path(top_dir):
     return os.path.join(top_dir, "src", "main", "resources", "dxWDL_runtime.conf")
 
-def build_dirs(project, version_id):
-    user_desc = pwd.getpwuid(os.getuid())
-    username = user_desc.pw_name
-    base_folder = "/builds/{}/{}".format(username, version_id)
+def build_subdirs(project, base_folder):
+    """ Creates subfolder in the base folder needed for running tests"""
     applet_folder = base_folder + "/applets"
     test_folder = base_folder + "/test"
     project.new_folder(test_folder, parents=True)
     project.new_folder(applet_folder, parents=True)
-    return base_folder
 
-def build_dir(project, folder)
-    project.new_folder(folder, parents=True)
+def build_dirs(project, version_id):
+    user_desc = pwd.getpwuid(os.getuid())
+    username = user_desc.pw_name
+    base_folder = "/builds/{}/{}".format(username, version_id)
+    build_subdirs(project, base_folder)
+    return base_folder
 
 def get_project(project_name):
     '''Try to find the project with the given name or id.'''


### PR DESCRIPTION
This commit will make it easier to run integration tests for the WDL compiler. 

The changes include:
- fix unit tests which don't kick off - change master to main in the existing workflow
- add `--clean` option to the `run_tests.py` script that removes the build folder after running tests
- integration tests will run when the `integration` label is set on a PR. This is to limit running them to devs with write access to the repo (write access is needed to set labels) and also limit the number of runs so that we don't incur too much cost. 
- the test script will now fail with a non-zero exit code if any of the workflows fail.
