### PR TITLE
Closure refactor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
 val dxCommonVersion = "0.2.1"
-val wdlToolsVersion = "0.10.2"
+val wdlToolsVersion = "0.10.3"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
 val dxCommonVersion = "0.2.1"
-val wdlToolsVersion = "0.10.3"
+val wdlToolsVersion = "0.10.4"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"

--- a/src/main/scala/dx/core/languages/wdl/WdlBlock.scala
+++ b/src/main/scala/dx/core/languages/wdl/WdlBlock.scala
@@ -407,7 +407,7 @@ object WdlBlock {
     // convert to blocks - keep only non-empty blocks
     parts.filter(_.nonEmpty).zipWithIndex.map {
       case (v, index) =>
-        val (inputs, outputs) = WdlUtils.getInputOutputClosure(v, withField = true)
+        val (inputs, outputs) = WdlUtils.getClosureInputsAndOutputs(v, withField = true)
         WdlBlock(index, WdlBlockInput.create(inputs), outputs.values.toVector, v)
     }
   }

--- a/src/main/scala/dx/executor/wdl/WdlWorkflowSupport.scala
+++ b/src/main/scala/dx/executor/wdl/WdlWorkflowSupport.scala
@@ -156,7 +156,7 @@ case class WdlWorkflowSupport(workflow: TAT.Workflow,
   }
 
   private def getBlockOutputs(elements: Vector[TAT.WorkflowElement]): Map[String, T] = {
-    val (_, outputs) = WdlUtils.getInputOutputClosure(elements, withField = false)
+    val (_, outputs) = WdlUtils.getClosureInputsAndOutputs(elements, withField = false)
     outputs.values.map {
       case TAT.OutputParameter(name, wdlType, _, _) => name -> wdlType
     }.toMap

--- a/src/main/scala/dx/translator/wdl/CallableTranslator.scala
+++ b/src/main/scala/dx/translator/wdl/CallableTranslator.scala
@@ -478,7 +478,7 @@ case class CallableTranslator(wdlBundle: WdlBundle,
     private def splitWorkflowElements(
         statements: Vector[TAT.WorkflowElement]
     ): (Vector[WdlBlockInput], Vector[WdlBlock], Vector[TAT.OutputParameter]) = {
-      val (inputs, outputs) = WdlUtils.getInputOutputClosure(statements, withField = true)
+      val (inputs, outputs) = WdlUtils.getClosureInputsAndOutputs(statements, withField = true)
       val subBlocks = WdlBlock.createBlocks(statements)
       (WdlBlockInput.create(inputs), subBlocks, outputs.values.toVector)
     }

--- a/src/test/resources/util/nested_closure.wdl
+++ b/src/test/resources/util/nested_closure.wdl
@@ -1,0 +1,46 @@
+version 1.0
+
+workflow nested_closure {
+    input {
+        Int i
+    }
+
+    # 1 - input=[i], output=[indexes]
+    # input=[i], output=[indexes]
+    Array[Int] indexes = range(i)
+
+    #2 - input=[i, x], output=[indexes]
+    # input=[i, x], output=[indexes]
+    scatter (x in indexes) {
+        # 3 - input=[i, x], output=[indexes, s]
+        # input=[i], output=[indexes, s]
+        String s = "item ~{x}"
+        # 5 - input=[i, x], output=[indexes, s, foo.out, t]
+        # input=[i, foo.out], output=[indexes]
+        String t = foo.out
+
+        # 4 - input=[i, x], output=[indexes, s, foo.out]
+        call foo {
+            input: s = s
+        }
+
+        # 10 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n, out]
+        Array[String] out = n
+
+        # 6 - input=[i, x, z], output=[indexes, s, foo.out, t]
+        scatter (z in [s, t]) {
+            # 9 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n]
+            String n = "~{sep=',' string}"
+
+            # 7 - input=[i, x, z, j], output=[indexes, s, foo.out, t]
+            scatter (j in [1,2]) {
+                # 8 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string]
+                String string = "~{j} ~{t}"
+            }
+        }
+    }
+
+    output {
+        Array[String] out2 = out
+    }
+}

--- a/src/test/resources/util/nested_closure.wdl
+++ b/src/test/resources/util/nested_closure.wdl
@@ -1,22 +1,24 @@
 version 1.0
 
+# This workflow demonstrates the need to sort elements by dependency
+# order, rather than process them in order of appearance, when computing
+# the inputs and outputs for each block of statements. For example, if
+# we processed elements in order of appearance, `foo.out` would be
+# classified as an input rather than an output, since it is referenced
+# prior to its definition.
 workflow nested_closure {
     input {
         Int i
     }
 
     # 1 - input=[i], output=[indexes]
-    # input=[i], output=[indexes]
     Array[Int] indexes = range(i)
 
     #2 - input=[i, x], output=[indexes]
-    # input=[i, x], output=[indexes]
     scatter (x in indexes) {
         # 3 - input=[i, x], output=[indexes, s]
-        # input=[i], output=[indexes, s]
         String s = "item ~{x}"
         # 5 - input=[i, x], output=[indexes, s, foo.out, t]
-        # input=[i, foo.out], output=[indexes]
         String t = foo.out
 
         # 4 - input=[i, x], output=[indexes, s, foo.out]
@@ -41,6 +43,16 @@ workflow nested_closure {
     }
 
     output {
-        Array[String] out2 = out
+        Array[Array[String]] out2 = out
+    }
+}
+
+task foo {
+    input {
+        String s
+    }
+    command {}
+    output {
+        String out = s
     }
 }

--- a/src/test/resources/util/nested_closure_no_fw_ref.wdl
+++ b/src/test/resources/util/nested_closure_no_fw_ref.wdl
@@ -1,0 +1,56 @@
+version 1.0
+
+# This is a version of the nested_closure workflow that doesn't have forward references.
+workflow nested_closure_no_fw_ref {
+  input {
+    Int i
+  }
+
+  # 1 - input=[i], output=[indexes]
+  Array[Int]+ indexes = [i, i + 1]
+
+  #2 - input=[i, x], output=[indexes]
+  scatter (x in indexes) {
+    # 3 - input=[i, x], output=[indexes, s]
+    String s = "item ~{x}"
+
+    # 4 - input=[i, x], output=[indexes, s, foo.out]
+    call foo {
+      input: s = s
+    }
+
+    # 5 - input=[i, x], output=[indexes, s, foo.out, t]
+    String t = foo.out
+
+    # 6 - input=[i, x], output=[indexes, s, foo.out, t]
+    # note that 'z' is never referenced, so it is not added
+    # to the inputs
+    scatter (z in [s, t]) {
+      # 7 - input=[i, x, z, j], output=[indexes, s, foo.out, t]
+      scatter (j in [1,2]) {
+        # 8 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string]
+        String string = "~{j} ~{t}"
+      }
+
+      # 9 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n]
+      String n = "~{sep=',' string}"
+    }
+
+    # 10 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n, out]
+    Array[String]+ out = n
+  }
+
+  output {
+    Array[Array[String]] out2 = out
+  }
+}
+
+task foo {
+  input {
+    String s
+  }
+  command {}
+  output {
+    String out = s
+  }
+}

--- a/src/test/scala/dx/core/languages/wdl/WdlUtilsTest.scala
+++ b/src/test/scala/dx/core/languages/wdl/WdlUtilsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import dx.util.{Bindings, FileSourceResolver}
 
-class UtilsTest extends AnyFlatSpec with Matchers {
+class WdlUtilsTest extends AnyFlatSpec with Matchers {
   private def validateTaskMeta(task: TAT.Task): Unit = {
     val kvs = task.meta match {
       case Some(TAT.MetaSection(kvs, _)) => kvs
@@ -86,7 +86,7 @@ class UtilsTest extends AnyFlatSpec with Matchers {
     validateTaskMeta(task)
   }
 
-  ignore should "parse the meta section in wdl 2.0" taggedAs EdgeTest in {
+  it should "parse the meta section in wdl 2.0" taggedAs EdgeTest in {
     val srcCode =
       """|version 2.0
          |

--- a/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
+++ b/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
@@ -256,7 +256,7 @@ class WorkflowExecutorTest extends AnyFlatSpec with Matchers {
     }
     results should be(
         Map(
-            "z" -> (WdlTypes.T_Optional(WdlTypes.T_Array(WdlTypes.T_Int, nonEmpty = false)),
+            "z" -> (WdlTypes.T_Optional(WdlTypes.T_Array(WdlTypes.T_Int, nonEmpty = true)),
             WdlValues.V_Null)
         )
     )


### PR DESCRIPTION
Refactor `getClosureInputsAndOutputs` to correctly handle out-of-order statements (i.e. forward references). This is a continuation of APPS-247 - I can either merge this with the `bugs/APPS-247` first, or wait until that one is merged and then change this PR to be against `main`.

This highlights the issue that forward references are currently not handled during type inference. I have added an issue (APPS-273) to address this later.

This PR also updates to wdlTools 0.10.4 to fix some issues with non-empty arrays, and updates the tests accordingly.