### PR TITLE
refactor getClosureInputsAndOutputs to respect dependency order

### DIFF
--- a/src/main/scala/dx/core/languages/wdl/WdlBlock.scala
+++ b/src/main/scala/dx/core/languages/wdl/WdlBlock.scala
@@ -407,7 +407,7 @@ object WdlBlock {
     // convert to blocks - keep only non-empty blocks
     parts.filter(_.nonEmpty).zipWithIndex.map {
       case (v, index) =>
-        val (inputs, outputs) = WdlUtils.getInputOutputClosure(v, withField = true)
+        val (inputs, outputs) = WdlUtils.getClosureInputsAndOutputs(v, withField = true)
         WdlBlock(index, WdlBlockInput.create(inputs), outputs.values.toVector, v)
     }
   }

--- a/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
+++ b/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
@@ -965,118 +965,109 @@ object WdlUtils {
     * @param elements the block elements
     * @return
     */
-  def getInputOutputClosure(
+  def getClosureInputsAndOutputs(
       elements: Vector[TAT.WorkflowElement],
       withField: Boolean
   ): (Map[String, (WdlTypes.T, InputKind.InputKind)], Map[String, TAT.OutputParameter]) = {
-    def inner(
+    def getOutputs(
         innerElements: Vector[TAT.WorkflowElement],
         innerWithField: Boolean
-    ): (Vector[WdlInputRef], Map[String, TAT.OutputParameter]) = {
-      // accumulate the inputs, outputs, and local definitions.
-      //
-      // start with:
-      //  an empty list of inputs
-      //  empty list of local definitions
-      //  empty list of outputs
-      innerElements.foldLeft(
-          (Vector.empty[WdlInputRef], Map.empty[String, TAT.OutputParameter])
-      ) {
-        case ((inputs, outputs), elem) =>
-          elem match {
-            case TAT.PrivateVariable(name, wdlType, expr, loc) =>
-              val newInputs =
-                inputs ++ getExpressionInputs(expr, innerWithField).filter { ref =>
-                  !outputs.contains(ref.fullyQualifiedName)
-                }
-              val newOutputs = outputs + (name -> TAT.OutputParameter(name, wdlType, expr, loc))
-              (newInputs, newOutputs)
-            case call: TAT.Call =>
-              val newInputs = inputs ++ WdlUtils
-                .getCallInputs(call)
-                .filter { ref =>
-                  !outputs.contains(ref.fullyQualifiedName)
-                }
-              val newOutputs = outputs ++ call.callee.output.map {
-                case (name, wdlType) =>
-                  val fqn = s"${call.actualName}.${name}"
-                  fqn -> TAT.OutputParameter(fqn,
-                                             wdlType,
-                                             TAT.ExprIdentifier(fqn, wdlType, call.loc),
-                                             call.loc)
-              }
-              (newInputs, newOutputs)
-            case cond: TAT.Conditional =>
-              val exprInputs = getExpressionInputs(cond.expr, innerWithField).filter { ref =>
-                !outputs.contains(ref.fullyQualifiedName)
-              }
-              // recurse into body of conditional
-              val (subBlockInputs, subBlockOutputs) =
-                inner(cond.body, innerWithField = true)
-              val newInputs = inputs ++ exprInputs ++ subBlockInputs
-              // make outputs optional
-              val newOutputs = outputs ++ subBlockOutputs.values.map {
-                case TAT.OutputParameter(name, wdlType, expr, loc) =>
-                  name -> TAT.OutputParameter(name, TypeUtils.ensureOptional(wdlType), expr, loc)
-              }
-              (newInputs, newOutputs)
-            case scatter: TAT.Scatter =>
-              val exprInputs = getExpressionInputs(scatter.expr, innerWithField).filter { ref =>
-                !outputs.contains(ref.fullyQualifiedName)
-              }
-              // recurse into body of the scatter
-              val (subBlockInputs, subBlockOutputs) = inner(scatter.body, innerWithField = true)
-              val updatedSubBlockInputs = subBlockInputs.map {
-                // if the scatter variable is referenced, ensure its kind is
-                // 'Computed' so it doesn't become a required input
-                case ref if ref.name == scatter.identifier => ref.copy(kind = InputKind.Computed)
-                case ref                                   => ref
-              }
-              val newInputs = inputs ++ exprInputs ++ updatedSubBlockInputs
-              // make outputs arrays, remove the collection iteration variable
-              val nonEmptyOutputArray = scatter.expr.wdlType match {
-                case T_Array(_, nonEmpty) => nonEmpty
-                case _ =>
-                  throw new Exception(
-                      s"scatter expression type ${scatter.expr.wdlType} not an array"
-                  )
-              }
-              val newOutputs = outputs ++ subBlockOutputs.values.collect {
-                case TAT.OutputParameter(name, wdlType, expr, loc) if name != scatter.identifier =>
-                  name -> TAT.OutputParameter(
-                      name,
-                      WdlTypes.T_Array(wdlType, nonEmpty = nonEmptyOutputArray),
-                      expr,
-                      loc
-                  )
-              }
-              (newInputs, newOutputs)
+    ): Vector[TAT.OutputParameter] = {
+      innerElements.flatMap {
+        case TAT.PrivateVariable(name, wdlType, expr, loc) =>
+          Vector(TAT.OutputParameter(name, wdlType, expr, loc))
+        case call: TAT.Call =>
+          call.callee.output.map {
+            case (name, wdlType) =>
+              val fqn = s"${call.actualName}.${name}"
+              TAT.OutputParameter(
+                  fqn,
+                  wdlType,
+                  TAT.ExprIdentifier(fqn, wdlType, call.loc),
+                  call.loc
+              )
+          }.toVector
+        case cond: TAT.Conditional =>
+          getOutputs(cond.body, innerWithField = true).map { out =>
+            out.copy(wdlType = TypeUtils.ensureOptional(out.wdlType))
+          }
+        case scatter: TAT.Scatter =>
+          // make outputs arrays, remove the collection iteration variable
+          val nonEmptyOutputArray = scatter.expr.wdlType match {
+            case T_Array(_, nonEmpty) => nonEmpty
+            case _ =>
+              throw new Exception(
+                  s"scatter expression type ${scatter.expr.wdlType} not an array"
+              )
+          }
+          getOutputs(scatter.body, innerWithField = true).collect {
+            case out: TAT.OutputParameter if out.name != scatter.identifier =>
+              out.copy(wdlType = WdlTypes.T_Array(out.wdlType, nonEmpty = nonEmptyOutputArray))
           }
       }
     }
-    val (inputs, outputs) = inner(elements, withField)
-    val inputMap = inputs
+
+    def getInputs(
+        innerElements: Vector[TAT.WorkflowElement],
+        innerWithField: Boolean
+    ): Vector[WdlInputRef] = {
+      innerElements.flatMap {
+        case v: TAT.PrivateVariable =>
+          getExpressionInputs(v.expr, innerWithField)
+        case call: TAT.Call =>
+          getCallInputs(call)
+        case cond: TAT.Conditional =>
+          // get inputs for the conditional expression
+          val exprInputs = getExpressionInputs(cond.expr, innerWithField)
+          // recurse into body of conditional
+          val bodyInputs = getInputs(cond.body, innerWithField = true)
+          exprInputs ++ bodyInputs
+        case scatter: TAT.Scatter =>
+          // get inputs for the scatter expression
+          val exprInputs = getExpressionInputs(scatter.expr, innerWithField)
+          // recurse into body of the scatter
+          // if the scatter variable is referenced, ensure its kind is
+          // 'Computed' so it doesn't become a required input
+          val bodyInputs = getInputs(scatter.body, innerWithField = true).map {
+            case ref if ref.name == scatter.identifier => ref.copy(kind = InputKind.Computed)
+            case ref                                   => ref
+          }
+          exprInputs ++ bodyInputs
+      }
+    }
+
+    // first convert outputs - we need to do this prior to
+    // inputs because WDL allows forward references, and we
+    // need to be able to distinguish block inputs from
+    // variables that are defined within the block
+    val outputs = getOutputs(elements, withField).groupBy(_.name).map {
+      case (name, outputs) if outputs.size == 1 => name -> outputs.head
+      case (name, outputs) if Set(outputs).size > 1 =>
+        throw new Exception(s"multiple outputs defined with the name ${name}: ${outputs}")
+    }
+
+    // now convert the inputs, excluding any output variables
+    val inputs = getInputs(elements, withField)
       .groupBy(_.fullyQualifiedName)
+      .filterNot(i => outputs.contains(i._1))
       .map {
-        case (fqn, refs) if refs.size == 1       => fqn -> refs.head
-        case (fqn, refs) if refs.toSet.size == 1 => fqn -> refs.head
-        case (fqn, refs)                         =>
+        case (fqn, refs) if refs.toSet.size == 1 =>
+          fqn -> (refs.head.wdlType, refs.head.kind)
+        case (fqn, refs) =>
           // there are multiple references to the same variable from different kinds of
           // input - sort by InputKind, pick the one with the highest priority (lowest
           // value), and make sure if there are multiple with the same kind that they're
           // all of the same type
-          val priorityRef = refs.groupBy(_.kind).toVector.sortWith(_._1 < _._1).head._2
-          if (priorityRef.map(_.wdlType).toSet.size > 1) {
+          val priorityRefs = refs.groupBy(_.kind).toVector.sortWith(_._1 < _._1).head._2
+          if (priorityRefs.map(_.wdlType).toSet.size > 1) {
             throw new Exception(
-                s"multiple references to the same paramter with different types: ${priorityRef}"
+                s"multiple references to the same paramter with different types: ${priorityRefs}"
             )
           }
-          fqn -> priorityRef.head
+          fqn -> (priorityRefs.head.wdlType, priorityRefs.head.kind)
       }
-      .view
-      .mapValues(ref => (ref.wdlType, ref.kind))
-      .toMap
-    (inputMap, outputs)
+
+    (inputs, outputs)
   }
 
   /**

--- a/src/main/scala/dx/executor/wdl/WdlWorkflowSupport.scala
+++ b/src/main/scala/dx/executor/wdl/WdlWorkflowSupport.scala
@@ -156,7 +156,7 @@ case class WdlWorkflowSupport(workflow: TAT.Workflow,
   }
 
   private def getBlockOutputs(elements: Vector[TAT.WorkflowElement]): Map[String, T] = {
-    val (_, outputs) = WdlUtils.getInputOutputClosure(elements, withField = false)
+    val (_, outputs) = WdlUtils.getClosureInputsAndOutputs(elements, withField = false)
     outputs.values.map {
       case TAT.OutputParameter(name, wdlType, _, _) => name -> wdlType
     }.toMap

--- a/src/main/scala/dx/translator/wdl/CallableTranslator.scala
+++ b/src/main/scala/dx/translator/wdl/CallableTranslator.scala
@@ -477,7 +477,7 @@ case class CallableTranslator(wdlBundle: WdlBundle,
     private def splitWorkflowElements(
         statements: Vector[TAT.WorkflowElement]
     ): (Vector[WdlBlockInput], Vector[WdlBlock], Vector[TAT.OutputParameter]) = {
-      val (inputs, outputs) = WdlUtils.getInputOutputClosure(statements, withField = true)
+      val (inputs, outputs) = WdlUtils.getClosureInputsAndOutputs(statements, withField = true)
       val subBlocks = WdlBlock.createBlocks(statements)
       (WdlBlockInput.create(inputs), subBlocks, outputs.values.toVector)
     }

--- a/src/test/resources/util/nested_closure.wdl
+++ b/src/test/resources/util/nested_closure.wdl
@@ -1,0 +1,58 @@
+version 1.0
+
+# This workflow demonstrates the need to sort elements by dependency
+# order, rather than process them in order of appearance, when computing
+# the inputs and outputs for each block of statements. For example, if
+# we processed elements in order of appearance, `foo.out` would be
+# classified as an input rather than an output, since it is referenced
+# prior to its definition.
+workflow nested_closure {
+  input {
+    Int i
+  }
+
+  # 1 - input=[i], output=[indexes]
+  Array[Int] indexes = range(i)
+
+  #2 - input=[i, x], output=[indexes]
+  scatter (x in indexes) {
+    # 3 - input=[i, x], output=[indexes, s]
+    String s = "item ~{x}"
+    # 5 - input=[i, x], output=[indexes, s, foo.out, t]
+    String t = foo.out
+
+    # 4 - input=[i, x], output=[indexes, s, foo.out]
+    call foo {
+      input: s = s
+    }
+
+    # 10 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n, out]
+    Array[String] out = n
+
+    # 6 - input=[i, x, z], output=[indexes, s, foo.out, t]
+    scatter (z in [s, t]) {
+      # 9 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n]
+      String n = "~{sep=',' string}"
+
+      # 7 - input=[i, x, z, j], output=[indexes, s, foo.out, t]
+      scatter (j in [1,2]) {
+        # 8 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string]
+        String string = "~{j} ~{t}"
+      }
+    }
+  }
+
+  output {
+    Array[Array[String]] out2 = out
+  }
+}
+
+task foo {
+  input {
+    String s
+  }
+  command {}
+  output {
+    String out = s
+  }
+}

--- a/src/test/resources/util/nested_closure_no_fw_ref.wdl
+++ b/src/test/resources/util/nested_closure_no_fw_ref.wdl
@@ -1,0 +1,56 @@
+version 1.0
+
+# This is a version of the nested_closure workflow that doesn't have forward references.
+workflow nested_closure_no_fw_ref {
+  input {
+    Int i
+  }
+
+  # 1 - input=[i], output=[indexes]
+  Array[Int]+ indexes = [i, i + 1]
+
+  #2 - input=[i, x], output=[indexes]
+  scatter (x in indexes) {
+    # 3 - input=[i, x], output=[indexes, s]
+    String s = "item ~{x}"
+
+    # 4 - input=[i, x], output=[indexes, s, foo.out]
+    call foo {
+      input: s = s
+    }
+
+    # 5 - input=[i, x], output=[indexes, s, foo.out, t]
+    String t = foo.out
+
+    # 6 - input=[i, x], output=[indexes, s, foo.out, t]
+    # note that 'z' is never referenced, so it is not added
+    # to the inputs
+    scatter (z in [s, t]) {
+      # 7 - input=[i, x, z, j], output=[indexes, s, foo.out, t]
+      scatter (j in [1,2]) {
+        # 8 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string]
+        String string = "~{j} ~{t}"
+      }
+
+      # 9 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n]
+      String n = "~{sep=',' string}"
+    }
+
+    # 10 - input=[i, x, z, j], output=[indexes, s, foo.out, t, string, n, out]
+    Array[String]+ out = n
+  }
+
+  output {
+    Array[Array[String]] out2 = out
+  }
+}
+
+task foo {
+  input {
+    String s
+  }
+  command {}
+  output {
+    String out = s
+  }
+}

--- a/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
+++ b/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
@@ -247,4 +247,38 @@ class WdlBlockTest extends AnyFlatSpec with Matchers {
 
     b00.kind shouldBe BlockKind.ConditionalOneCall
   }
+
+  it should "generate correct closure inputs and outputs" in {
+    val doc = getDocument("util", "nested_closure_no_fw_ref.wdl")
+    val blocks = WdlBlock.createBlocks(doc.workflow.get.body)
+    blocks.size shouldBe 1
+    blocks.head.inputs.iterator sameElements {
+      Vector(RequiredBlockInput("i", WdlTypes.T_Int),
+             ComputedBlockInput("x", WdlTypes.T_Int),
+             ComputedBlockInput("j", WdlTypes.T_Int))
+    }
+    blocks.head.outputs.sortWith(_.name < _.name) should matchPattern {
+      case Vector(
+          TAT.OutputParameter("foo.out", WdlTypes.T_Array(WdlTypes.T_String, true), _, _),
+          TAT.OutputParameter("indexes", WdlTypes.T_Array(WdlTypes.T_Int, true), _, _),
+          TAT.OutputParameter("n",
+                              WdlTypes.T_Array(WdlTypes.T_Array(WdlTypes.T_String, true), true),
+                              _,
+                              _),
+          TAT.OutputParameter("out",
+                              WdlTypes.T_Array(WdlTypes.T_Array(WdlTypes.T_String, true), true),
+                              _,
+                              _),
+          TAT.OutputParameter("s", WdlTypes.T_Array(WdlTypes.T_String, true), _, _),
+          TAT.OutputParameter("string",
+                              WdlTypes.T_Array(
+                                  WdlTypes.T_Array(WdlTypes.T_Array(WdlTypes.T_String, true), true),
+                                  true
+                              ),
+                              _,
+                              _),
+          TAT.OutputParameter("t", WdlTypes.T_Array(WdlTypes.T_String, true), _, _)
+          ) =>
+    }
+  }
 }

--- a/src/test/scala/dx/core/languages/wdl/WdlUtilsTest.scala
+++ b/src/test/scala/dx/core/languages/wdl/WdlUtilsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import dx.util.{Bindings, FileSourceResolver}
 
-class UtilsTest extends AnyFlatSpec with Matchers {
+class WdlUtilsTest extends AnyFlatSpec with Matchers {
   private def validateTaskMeta(task: TAT.Task): Unit = {
     val kvs = task.meta match {
       case Some(TAT.MetaSection(kvs, _)) => kvs


### PR DESCRIPTION
Refactor getClosureInputsAndOutputs to correctly handle out-of-order statements (i.e. forward references). This is a continuation of APPS-247 - I can either merge this with the bugs/APPS-247 first, or wait until that one is merged and then change this PR to be against main.

This highlights the issue that forward references are currently not handled during type inference. I have added an issue (APPS-273) to address this later.