### PR TITLE
upgrade to wdlTools 0.10.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ assemblyOutputPath in assembly := file("applet_resources/resources/dxWDL.jar")
 assemblyMergeStrategy in assembly := customMergeStrategy.value
 
 val dxCommonVersion = "0.2.2"
-val wdlToolsVersion = "0.10.5"
+val wdlToolsVersion = "0.10.7"
 val typesafeVersion = "1.3.3"
 val sprayVersion = "1.3.5"
 val jacksonVersion = "2.11.0"


### PR DESCRIPTION
This fixes two bugs uncovered in RC5
- struct literals rendered incorrectly for v1
- array type-checking is too strict (can't coerce between empty and non-empty array types)