### PR TITLE
APPS-291 unit-tests GHA fix

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,5 +1,6 @@
 name: Unit Tests
 
+
 on:
   push:
     branches:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,6 +1,5 @@
 name: Unit Tests
 
-
 on:
   push:
     branches:
@@ -8,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-
 
 jobs:
   test:

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -16,6 +16,9 @@ import org.scalatest.matchers.should.Matchers
 import spray.json._
 import dx.util.{FileUtils, Logger, SysUtils}
 import dxCompiler.Main
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID.randomUUID
 
 // This test module requires being logged in to the platform.
 // It compiles WDL scripts without the runtime library.
@@ -80,12 +83,15 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 //    case _                       => throw new Exception("boo")
 //  }
 //  println(task.requirements)
-  private val reorgAppletFolder = s"/${unitTestsPath}/reorg_applets/"
+
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
+  val test_time =  dateFormatter.format(LocalDateTime.now)
+
+  private val reorgAppletFolder = s"/${unitTestsPath}/reorg_applets_${test_time}_${randomUUID().toString.substring(24)}/"
   private val reorgAppletPath = s"${reorgAppletFolder}/functional_reorg_test"
 
   override def beforeAll(): Unit = {
     // build the directory with the native applets
-    dxTestProject.removeFolder(reorgAppletFolder, recurse = true)
     dxTestProject.newFolder(reorgAppletFolder, parents = true)
     // building necessary applets before starting the tests
     val nativeApplets = Vector("functional_reorg_test")
@@ -100,6 +106,10 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         case _: Throwable =>
       }
     }
+  }
+
+  override def afterAll(): Unit = {
+    dxTestProject.removeFolder(reorgAppletFolder, recurse = true)
   }
 
   private def getAppletId(path: String): String = {

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -84,7 +84,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 //  }
 //  println(task.requirements)
 
-  val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
   val test_time =  dateFormatter.format(LocalDateTime.now)
 
   private val reorgAppletFolder = s"/${unitTestsPath}/reorg_applets_${test_time}_${randomUUID().toString.substring(24)}/"

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -24,7 +24,7 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
   private val dxApi = DxApi()(logger)
 
   val testProject = "dxCompiler_playground"
-  val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
   val test_time =  dateFormatter.format(LocalDateTime.now)
 
   private lazy val dxTestProject =
@@ -60,6 +60,10 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
           logger = Logger.Quiet
       )
     }
+  }
+
+  override def afterAll(): Unit = {
+    dxTestProject.removeFolder(folderPath, recurse = true)
   }
 
   private def parseWdlTasks(

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -12,9 +12,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import dx.util.{FileUtils, Logger, SysUtils}
+import dxCompiler.Main
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import dxCompiler.Main
 import java.util.UUID.randomUUID
 
 class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -23,7 +23,7 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
   private val logger = Logger.Quiet
   private val dxApi = DxApi()(logger)
 
-  val testProject = "dxCompiler_playground"
+  val testProject = "dxWDL_playground"
   val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
   val test_time =  dateFormatter.format(LocalDateTime.now)
 

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -12,7 +12,10 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wdlTools.types.{WdlTypes, TypedAbstractSyntax => TAT}
 import dx.util.{FileUtils, Logger, SysUtils}
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import dxCompiler.Main
+import java.util.UUID.randomUUID
 
 class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   assume(isLoggedIn)
@@ -21,6 +24,8 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
   private val dxApi = DxApi()(logger)
 
   val testProject = "dxCompiler_playground"
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
+  val test_time =  dateFormatter.format(LocalDateTime.now)
 
   private lazy val dxTestProject =
     try {
@@ -35,11 +40,10 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
 
   private val username = System.getProperty("user.name")
   private val unitTestsPath = s"unit_tests/${username}"
-  private val folderPath = s"/${unitTestsPath}/applets/"
+  private val folderPath = s"/${unitTestsPath}/applets_${test_time}_${randomUUID().toString.substring(24)}/"
 
   override def beforeAll(): Unit = {
     // build the directory with the native applets
-    dxTestProject.removeFolder(folderPath, recurse = true)
     dxTestProject.newFolder(folderPath, parents = true)
     // building necessary applets before starting the tests
     val nativeApplets = Vector(

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -23,7 +23,7 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
   private val logger = Logger.Quiet
   private val dxApi = DxApi()(logger)
 
-  val testProject = "dxWDL_playground"
+  val testProject = "dxCompiler_playground"
   val dateFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH-mm")
   val test_time =  dateFormatter.format(LocalDateTime.now)
 


### PR DESCRIPTION
Problem with paralel tests was probably caused due to two sets of tests creating/deleting applets folder which tests use. Currently no applets are removed and folders are named using timestamp and UUID (timestamp for easier debugging when browsing filesystem and UUID is used in case two tests were started at the same time)

Applets-folder-deletion mechanism is changed from "Deleted when starting" to "deleted after tests are finished. Is this fine?