### PR TITLE
APPS-329 Update file URL, use generic IDs in documentation. 

### DIFF
--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -85,9 +85,10 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 //  println(task.requirements)
 
   val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
-  val test_time =  dateFormatter.format(LocalDateTime.now)
+  val test_time = dateFormatter.format(LocalDateTime.now)
 
-  private val reorgAppletFolder = s"/${unitTestsPath}/reorg_applets_${test_time}_${randomUUID().toString.substring(24)}/"
+  private val reorgAppletFolder =
+    s"/${unitTestsPath}/reorg_applets_${test_time}_${randomUUID().toString.substring(24)}/"
   private val reorgAppletPath = s"${reorgAppletFolder}/functional_reorg_test"
 
   override def beforeAll(): Unit = {

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -25,7 +25,7 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
 
   val testProject = "dxCompiler_playground"
   val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
-  val test_time =  dateFormatter.format(LocalDateTime.now)
+  val test_time = dateFormatter.format(LocalDateTime.now)
 
   private lazy val dxTestProject =
     try {
@@ -40,7 +40,8 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
 
   private val username = System.getProperty("user.name")
   private val unitTestsPath = s"unit_tests/${username}"
-  private val folderPath = s"/${unitTestsPath}/applets_${test_time}_${randomUUID().toString.substring(24)}/"
+  private val folderPath =
+    s"/${unitTestsPath}/applets_${test_time}_${randomUUID().toString.substring(24)}/"
 
   override def beforeAll(): Unit = {
     // build the directory with the native applets

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -70,9 +70,10 @@ has input file
 
 ```
 {
-  "files.f": "dx://file-F5gkKkQ0ZvgjG3g16xyFf7b1",
-  "files.f1": "dx://file-F5gkQ3Q0ZvgzxKZ28JX5YZjy",
-  "files.f2": "dx://file-F5gkPXQ0Zvgp2y4Q8GJFYZ8G"
+  "files.f": "dx://file-wwww",
+  "files.f1": "dx://file-xxxx",
+  "files.f2": "dx://file-yyyy",
+  "files.fruit_list": "dx://file-zzzz"
 }
 ```
 
@@ -86,13 +87,16 @@ generates a `test/files_input.dx.json` file that looks like this:
 ```
 {
   "f": {
-    "$dnanexus_link": "file-F5gkKkQ0ZvgjG3g16xyFf7b1"
+    "$dnanexus_link": "file-wwww"
   },
   "f1": {
-    "$dnanexus_link": "file-F5gkQ3Q0ZvgzxKZ28JX5YZjy"
+    "$dnanexus_link": "file-xxxx"
   },
   "f2": {
-    "$dnanexus_link": "file-F5gkPXQ0Zvgp2y4Q8GJFYZ8G"
+    "$dnanexus_link": "file-yyyy"
+  },
+  "fruit_list": {
+    "$dnanexus_link": "file-zzzz"
   }
 }
 ```

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -65,7 +65,7 @@ The `-inputs` option allows specifying a Cromwell JSON
 [format](https://software.broadinstitute.org/wdl/documentation/inputs.php)
 inputs file. An equivalent DNAx format inputs file is generated from
 it. For example, workflow
-[files](https://github.com/dnanexus/dxCompiler/blob/master/test/files.wdl)
+[files](https://github.com/dnanexus/dxCompiler/blob/main/test/draft2/files.wdl)
 has input file
 
 ```


### PR DESCRIPTION
APPS-329 Update file URL, use generic IDs in documentation. 

The other changes were done by the scalafmt commit hook. 