### PR TITLE
APPS-389: handle optional non-file object inputs in native app(let)s

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## in dev
+
+* DxNI handles native app(let)s with optional non-file object inputs
+
 ## 2.1.1. 09-02-2021
 
 * Fixes errors due to expression evaluator not handling values wrapped in V\_Optional

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ val executorCwl = project
 lazy val dependencies =
   new {
     val dxCommonVersion = "0.2.5"
-    val dxApiVersion = "0.1.8"
+    val dxApiVersion = "0.1.9"
     val dxFileAccessProtocolsVersion = "0.1.2"
     val wdlToolsVersion = "0.12.3"
     val cwlScalaVersion = "0.3.4"

--- a/compiler/src/main/scala/dx/dxni/wdl/WdlNativeInterfaceGenerator.scala
+++ b/compiler/src/main/scala/dx/dxni/wdl/WdlNativeInterfaceGenerator.scala
@@ -77,7 +77,19 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
   private def wdlTypeFromDxClass(appletName: String,
                                  argName: String,
                                  ioClass: DxIOClass.Value,
-                                 isOptional: Boolean): WdlTypes.T = {
+                                 isOptional: Boolean): Option[WdlTypes.T] = {
+    if (ioClass == DxIOClass.Other) {
+      if (isOptional) {
+        logger.warning(s"ignoring applet ${appletName} optional non-file object input ${argName}")
+        return None
+      } else {
+        throw new Exception(
+            s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
+                |has non-optional non-file object input ${argName}""".stripMargin
+              .replaceAll("\n", " ")
+        )
+      }
+    }
     val (t, isArray) = ioClass match {
       case DxIOClass.Boolean      => (WdlTypes.T_Boolean, false)
       case DxIOClass.Int          => (WdlTypes.T_Int, false)
@@ -94,31 +106,29 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
         throw new Exception(s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
                                 |has IO class ${ioClass}""".stripMargin.replaceAll("\n", " "))
     }
-    if (isArray) {
+    Some(if (isArray) {
       WdlTypes.T_Array(t, !isOptional)
     } else if (isOptional) {
       WdlTypes.T_Optional(t)
     } else {
       t
-    }
+    })
   }
 
   private def appToWdlInterface(dxAppDesc: DxAppDescribe): Option[TAT.Task] = {
     val appName = dxAppDesc.name
     try {
       val inputSpec: Map[String, WdlTypes.T] =
-        dxAppDesc.inputSpec.get.map { ioSpec =>
-          ioSpec.name -> wdlTypeFromDxClass(dxAppDesc.name,
-                                            ioSpec.name,
-                                            ioSpec.ioClass,
-                                            ioSpec.optional)
+        dxAppDesc.inputSpec.get.flatMap { ioSpec =>
+          wdlTypeFromDxClass(dxAppDesc.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional).map(
+              ioSpec.name -> _
+          )
         }.toMap
       val outputSpec: Map[String, WdlTypes.T] =
-        dxAppDesc.outputSpec.get.map { ioSpec =>
-          ioSpec.name -> wdlTypeFromDxClass(dxAppDesc.name,
-                                            ioSpec.name,
-                                            ioSpec.ioClass,
-                                            ioSpec.optional)
+        dxAppDesc.outputSpec.get.flatMap { ioSpec =>
+          wdlTypeFromDxClass(dxAppDesc.name, ioSpec.name, ioSpec.ioClass, ioSpec.optional).map(
+              ioSpec.name -> _
+          )
         }.toMap
       // DNAnexus applets allow the same variable name to be used for inputs and outputs.
       // This is illegal in WDL.
@@ -134,6 +144,7 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
       Some(createDnanexusStub(dxAppDesc.id, dxAppDesc.name, inputSpec, outputSpec))
     } catch {
       case e: Throwable =>
+        println(e)
         logger.warning(
             s"Unable to construct a WDL interface for app ${appName}",
             exception = Some(e)
@@ -147,17 +158,21 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
   // We can translate with primitive types, and their arrays. Hashes cannot
   // be translated; applets that have them cannot be converted.
   private def wdlTypesOfDxApplet(
-      aplName: String,
+      appletName: String,
       desc: DxAppletDescribe
   ): (Map[String, WdlTypes.T], Map[String, WdlTypes.T]) = {
-    logger.trace(s"analyzing applet ${aplName}")
+    logger.trace(s"analyzing applet ${appletName}")
     val inputSpec: Map[String, WdlTypes.T] =
-      desc.inputSpec.get.map { iSpec =>
-        iSpec.name -> wdlTypeFromDxClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+      desc.inputSpec.get.flatMap { ioSpec =>
+        wdlTypeFromDxClass(appletName, ioSpec.name, ioSpec.ioClass, ioSpec.optional).map(
+            ioSpec.name -> _
+        )
       }.toMap
     val outputSpec: Map[String, WdlTypes.T] =
-      desc.outputSpec.get.map { iSpec =>
-        iSpec.name -> wdlTypeFromDxClass(aplName, iSpec.name, iSpec.ioClass, iSpec.optional)
+      desc.outputSpec.get.flatMap { ioSpec =>
+        wdlTypeFromDxClass(appletName, ioSpec.name, ioSpec.ioClass, ioSpec.optional).map(
+            ioSpec.name -> _
+        )
       }.toMap
     (inputSpec, outputSpec)
   }

--- a/compiler/src/main/scala/dx/dxni/wdl/WdlNativeInterfaceGenerator.scala
+++ b/compiler/src/main/scala/dx/dxni/wdl/WdlNativeInterfaceGenerator.scala
@@ -85,7 +85,7 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
       } else {
         throw new Exception(
             s"""|Cannot call applet ${appletName} from WDL, argument ${argName}
-                |has non-optional non-file object input ${argName}""".stripMargin
+                |has required non-file object input of type ${ioClass}""".stripMargin
               .replaceAll("\n", " ")
         )
       }
@@ -144,7 +144,6 @@ case class WdlNativeInterfaceGenerator(wdlVersion: WdlVersion,
       Some(createDnanexusStub(dxAppDesc.id, dxAppDesc.name, inputSpec, outputSpec))
     } catch {
       case e: Throwable =>
-        println(e)
         logger.warning(
             s"Unable to construct a WDL interface for app ${appName}",
             exception = Some(e)

--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -502,18 +502,22 @@ object Main {
         "force",
         "recursive"
     ).map(options.getFlag(_))
-    val apps = options
-      .getValue[String]("apps")
-      .map(AppsOption.withNameIgnoreCase)
-      .getOrElse(
-          if (appsOnly || pathIsAppId) {
-            AppsOption.Only
-          } else if (Vector(projectOpt, folderOpt, pathOpt).exists(_.isDefined)) {
-            AppsOption.Exclude
-          } else {
-            AppsOption.Include
-          }
-      )
+    val apps = if (pathIsAppId) {
+      AppsOption.Only
+    } else {
+      options
+        .getValue[String]("apps")
+        .map(AppsOption.withNameIgnoreCase)
+        .getOrElse(
+            if (appsOnly) {
+              AppsOption.Only
+            } else if (Vector(projectOpt, folderOpt, pathOpt).exists(_.isDefined)) {
+              AppsOption.Exclude
+            } else {
+              AppsOption.Include
+            }
+        )
+    }
 
     def writeOutput(doc: Vector[String]): Unit = {
       val path = outputPath.map { path =>

--- a/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
+++ b/compiler/src/test/scala/dx/dxni/DxNativeInterfaceTest.scala
@@ -23,9 +23,9 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
   private val logger = Logger.Quiet
   private val dxApi = DxApi()(logger)
 
-  val testProject = "dxCompiler_playground"
-  val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
-  val test_time = dateFormatter.format(LocalDateTime.now)
+  private val testProject = "dxCompiler_playground"
+  private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
+  private val test_time = dateFormatter.format(LocalDateTime.now)
 
   private lazy val dxTestProject =
     try {
@@ -128,6 +128,19 @@ class DxNativeInterfaceTest extends AnyFlatSpec with Matchers with BeforeAndAfte
     )
     val tasks = runDxni(args)
     tasks.keySet shouldBe Set("native_sum")
+  }
+
+  it should "be able to build an interface to a specific app" taggedAs NativeTest in {
+    val args = Vector(
+        "-force",
+        "-quiet",
+        "-path",
+        "app-data_model_loader_v2",
+        "-language",
+        "wdl_1_0"
+    )
+    val tasks = runDxni(args)
+    tasks.keySet shouldBe Set("data_model_loader_v2")
   }
 
   it should "build an interface to an applet specified by ID" taggedAs NativeTest in {


### PR DESCRIPTION
Currently, dxni skips any app(let)s with unsupported parameter types, but in the case of optional unsupported types, we can just ignore them.

This also updates to dxApi 0.1.9 to fix a bug with app (and globalworkflow) object ID parsing.