### PR TITLE
APPS-344 Native tasks should use instance type from native app/let, not wrapper task.

### DIFF
--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -118,6 +118,10 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       case static: StaticInstanceType                => instanceTypeDb.apply(static.toInstanceTypeRequest)
       case DefaultInstanceType | DynamicInstanceType => instanceTypeDb.defaultInstanceType
     }
+
+    // TODO REMOVE
+    logger.trace(s"__ Instance type for ${applet.name} is ${instanceType}")
+
     // Generate the applet's job script
     val jobScript = generateJobScript(applet)
     // build the run spec

--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -118,12 +118,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       case static: StaticInstanceType                => instanceTypeDb.apply(static.toInstanceTypeRequest)
       case DefaultInstanceType | DynamicInstanceType => instanceTypeDb.defaultInstanceType
     }
-
-    // TODO REMOVE
-    logger.trace(s"--------> Applet name ${applet.name}")
-    logger.trace(s"--------> Applet instance type ${applet.instanceType}")
-    logger.trace(s"--------> Resolved instance type ${instanceType}")
-
     // Generate the applet's job script
     val jobScript = generateJobScript(applet)
     // build the run spec
@@ -153,7 +147,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       case Some(dta) => dta.getRunSpecJson
       case None      => Map.empty
     }
-
     // runtime hints in the task override defaults from extras
     val taskOverrides: Map[String, JsValue] = applet.requirements
       .collect {
@@ -168,7 +161,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       }
       .flatten
       .toMap
-
     // task-specific settings from extras override runtime hints in the task
     val taskSpecificOverrides = applet.kind match {
       case ExecutableKindApplet =>
@@ -178,7 +170,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
         }
       case _ => Map.empty
     }
-
     // If the docker image is a tarball, add a link in the details field.
     val dockerFile: Option[DxFile] = applet.container match {
       case DxFileDockerImage(_, dxfile) => Some(dxfile)

--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -120,7 +120,9 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
     }
 
     // TODO REMOVE
-    logger.trace(s"__ Instance type for ${applet.name} is ${instanceType}")
+    logger.trace(s"--------> Applet name ${applet.name}")
+    logger.trace(s"--------> Applet instance type ${applet.instanceType}")
+    logger.trace(s"--------> Resolved instance type ${instanceType}")
 
     // Generate the applet's job script
     val jobScript = generateJobScript(applet)
@@ -152,9 +154,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       case None      => Map.empty
     }
 
-    // TODO REMOVE
-    logger.trace(s"__ extrasOverrides ${applet.name} are ${extrasOverrides}")
-
     // runtime hints in the task override defaults from extras
     val taskOverrides: Map[String, JsValue] = applet.requirements
       .collect {
@@ -170,9 +169,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       .flatten
       .toMap
 
-    // TODO REMOVE
-    logger.trace(s"__ taskOverrides for ${applet.name} are ${taskOverrides}")
-
     // task-specific settings from extras override runtime hints in the task
     val taskSpecificOverrides = applet.kind match {
       case ExecutableKindApplet =>
@@ -182,9 +178,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
         }
       case _ => Map.empty
     }
-
-    // TODO REMOVE
-    logger.trace(s"__ taskSpecificOverrides for ${applet.name} are ${taskSpecificOverrides}")
 
     // If the docker image is a tarball, add a link in the details field.
     val dockerFile: Option[DxFile] = applet.container match {

--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -151,6 +151,10 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       case Some(dta) => dta.getRunSpecJson
       case None      => Map.empty
     }
+
+    // TODO REMOVE
+    logger.trace(s"__ extrasOverrides ${applet.name} are ${extrasOverrides}")
+
     // runtime hints in the task override defaults from extras
     val taskOverrides: Map[String, JsValue] = applet.requirements
       .collect {
@@ -165,6 +169,10 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       }
       .flatten
       .toMap
+
+    // TODO REMOVE
+    logger.trace(s"__ taskOverrides for ${applet.name} are ${taskOverrides}")
+
     // task-specific settings from extras override runtime hints in the task
     val taskSpecificOverrides = applet.kind match {
       case ExecutableKindApplet =>
@@ -174,6 +182,10 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
         }
       case _ => Map.empty
     }
+
+    // TODO REMOVE
+    logger.trace(s"__ taskSpecificOverrides for ${applet.name} are ${taskSpecificOverrides}")
+
     // If the docker image is a tarball, add a link in the details field.
     val dockerFile: Option[DxFile] = applet.container match {
       case DxFileDockerImage(_, dxfile) => Some(dxfile)

--- a/core/src/main/scala/dx/core/ir/ValueSerde.scala
+++ b/core/src/main/scala/dx/core/ir/ValueSerde.scala
@@ -10,7 +10,7 @@ object ValueSerde extends DefaultJsonProtocol {
   val WrappedValueKey = "value___"
 
   case class ValueSerdeException(message: String) extends Exception(message)
-  
+
   /**
     * Serializes a Value to JSON.
     * @param value the Value to serialize

--- a/core/src/main/scala/dx/core/languages/wdl/CodeGenerator.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/CodeGenerator.scala
@@ -1,6 +1,13 @@
 package dx.core.languages.wdl
 
-import dx.core.ir.{Application, Callable, DocumentSource, ExecutableKindApplet, WorkflowSource}
+import dx.core.ir.{
+  Application,
+  Callable,
+  DocumentSource,
+  ExecutableKindApplet,
+  ExecutableKindNative,
+  WorkflowSource
+}
 import dx.util.{Logger, StringFileNode}
 import wdlTools.eval.WdlValues
 import wdlTools.syntax.{CommentMap, SourceLocation, WdlVersion}
@@ -153,7 +160,7 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
      }
     }
    */
-  private def createTaskStub(callable: Callable): TAT.Task = {
+  private def createTaskStub(callable: Callable, native: Boolean = false): TAT.Task = {
     /*Utils.trace(verbose.on,
                     s"""|taskHeader  callable=${callable.name}
                         |  inputs= ${callable.inputVars.map(_.name)}
@@ -186,6 +193,17 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
           TAT.OutputParameter(parameter.name, wdlType, defaultVal, SourceLocation.empty)
         }
 
+    val meta = if (native) {
+      Some(
+          TAT.MetaSection(
+              TreeSeqMap("type" -> TAT.MetaValueBoolean(value = true, SourceLocation.empty)),
+              SourceLocation.empty
+          )
+      )
+    } else {
+      None
+    }
+
     TAT.Task(
         callable.name,
         WdlTypes.T_Task(
@@ -205,7 +223,7 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
         outputs,
         TAT.CommandSection(Vector.empty, SourceLocation.empty),
         Vector.empty,
-        None,
+        meta,
         None,
         None,
         None,
@@ -214,7 +232,7 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
   }
 
   /**
-    * Generate a WDL stub fore a DNAnexus applet.
+    * Generate a WDL stub for a DNAnexus applet.
     * @param id the applet ID
     * @param appletName the applet name
     * @param inputSpec the applet inputs
@@ -339,6 +357,12 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
                   }
                   assert(tasks.size == 1)
                   tasks.head
+                case app: Application =>
+                  val native = app.kind match {
+                    case _: ExecutableKindNative => true
+                    case _                       => false
+                  }
+                  createTaskStub(callable, native = native)
                 case _ =>
                   // no existing stub, create it
                   createTaskStub(callable)

--- a/core/src/main/scala/dx/core/languages/wdl/CodeGenerator.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/CodeGenerator.scala
@@ -362,6 +362,7 @@ case class CodeGenerator(typeAliases: Map[String, WdlTypes.T_Struct],
                     case _: ExecutableKindNative => true
                     case _                       => false
                   }
+                  // no existing stub, create it - specify whether the target app(let) is native
                   createTaskStub(callable, native = native)
                 case _ =>
                   // no existing stub, create it

--- a/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
+++ b/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
@@ -337,8 +337,12 @@ case class WdlWorkflowExecutor(docSource: FileNode,
         val meta: Meta = Meta.create(versionSupport.version, task.meta)
         val isNative = meta.get("type", Vector(T_Boolean)) match {
           case Some(V_Boolean(b)) => b
-          case _ => false
+          case _                  => false
         }
+
+        logger.trace(s"--------> Meta ${meta}")
+        logger.trace(s"--------> isNative? ${isNative}")
+
         if (isNative) {
           None
         } else {
@@ -353,11 +357,11 @@ case class WdlWorkflowExecutor(docSource: FileNode,
             callIO.inputsFromValues(inputWdlValues, evaluator, ignoreDefaultEvalError = false)
           val runtime =
             Runtime(versionSupport.version,
-              task.runtime,
-              task.hints,
-              evaluator,
-              None,
-              ctx = Some(callInputs))
+                    task.runtime,
+                    task.hints,
+                    evaluator,
+                    None,
+                    ctx = Some(callInputs))
           try {
             val request = runtime.parseInstanceType
             val instanceType = jobMeta.instanceTypeDb.apply(request)
@@ -366,16 +370,19 @@ case class WdlWorkflowExecutor(docSource: FileNode,
           } catch {
             case e: Throwable =>
               logger.traceLimited(
-                s"""|Failed to precalculate the instance type for
-                    |task ${task.name}.
-                    |
-                    |${e}
-                    |""".stripMargin
+                  s"""|Failed to precalculate the instance type for
+                      |task ${task.name}.
+                      |
+                      |${e}
+                      |""".stripMargin
               )
               None
           }
         }
       }
+
+      logger.trace(s"--------> launchCall called with instance type ${instanceType}")
+
       val (dxExecution, execName) =
         launchJob(executableLink,
                   call.actualName,

--- a/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
+++ b/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
@@ -339,10 +339,6 @@ case class WdlWorkflowExecutor(docSource: FileNode,
           case Some(V_Boolean(b)) => b
           case _                  => false
         }
-
-        logger.trace(s"--------> Meta ${meta}")
-        logger.trace(s"--------> isNative? ${isNative}")
-
         if (isNative) {
           None
         } else {
@@ -380,8 +376,6 @@ case class WdlWorkflowExecutor(docSource: FileNode,
           }
         }
       }
-
-      logger.trace(s"--------> launchCall called with instance type ${instanceType}")
 
       val (dxExecution, execName) =
         launchJob(executableLink,


### PR DESCRIPTION
Don't use instance type from wrapper task on native task.
When generating task stub, include meta section with type=native for native task.
