### PR TITLE
APPS-324 Set build script to run on python3; fix test step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           dx mkdir $FOLDER
           python3 scripts/run_tests.py --test L --folder $FOLDER --project $PROJECT
           #TODO: also remove the folder when the tests fail
-          dx rmdir $FOLDER
+          dx rmdir -r $FOLDER
 
       - name: Extract release notes and set version in application.conf files
         id: update-release

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This script builds a dxCompiler release. A release consists of the client (dxCompiler.jar),
 # which is uploaded to
 


### PR DESCRIPTION
This is to fix:

```
building staging release
  File "/home/runner/work/dxCompiler/dxCompiler/scripts/build_release.py", line 54
    file=sys.stderr)
        ^
SyntaxError: invalid syntax
Error: Process completed with exit code 1.
```