### PR TITLE
Ignore default values in native app stubs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Adds `-separateOutputs` option to store output from each call in a separate folder
 * Fixes issue with referencing optional variables in the command block
+* Ignores default values from native app stubs that can cause errors during compilation
 
 ## 2.2.1 17-02-2021
 

--- a/compiler/src/test/resources/bugs/native_with_file_output.wdl
+++ b/compiler/src/test/resources/bugs/native_with_file_output.wdl
@@ -1,0 +1,43 @@
+version 1.0
+
+workflow native_with_file_output {
+  input {
+    Array[String]+ f_urls
+    String target_s3
+    File config_file
+    String up_dir
+  }
+
+  call aws_s3_to_platform_files {
+    input: f_urls = f_urls, target_s3 = target_s3, config_file = config_file, up_dir = up_dir
+  }
+
+  output {
+    Array[File]+ transferred_files = aws_s3_to_platform_files.transferred_files
+  }
+}
+
+task aws_s3_to_platform_files {
+  input {
+    Array[String]+ f_urls
+    String target_s3
+    File config_file
+    String up_dir
+    Int worker_max = 1
+    String bandwidth = "alot"
+    String? additional_upload_param
+    Boolean upload_direct_to_proj = true
+  }
+
+  command <<< >>>
+
+  output {
+    File upload_report = "placeholder.txt"
+    Array[File]+ transferred_files = ["placeholder.txt"]
+  }
+
+  meta {
+    type: "native"
+    id: "app-F0px8Y005x8p3Z3B8pzx3VfZ"
+  }
+}

--- a/compiler/src/test/resources/bugs/native_with_file_output.wdl
+++ b/compiler/src/test/resources/bugs/native_with_file_output.wdl
@@ -1,5 +1,7 @@
 version 1.0
 
+import "subwf.wdl" as sub
+
 workflow native_with_file_output {
   input {
     Array[String]+ f_urls
@@ -12,8 +14,12 @@ workflow native_with_file_output {
     input: f_urls = f_urls, target_s3 = target_s3, config_file = config_file, up_dir = up_dir
   }
 
+  call sub.foo {
+    input: inp = aws_s3_to_platform_files.transferred_files
+  }
+
   output {
-    Array[File]+ transferred_files = aws_s3_to_platform_files.transferred_files
+    Array[File]+ transferred_files = foo.out
   }
 }
 

--- a/compiler/src/test/resources/bugs/subwf.wdl
+++ b/compiler/src/test/resources/bugs/subwf.wdl
@@ -1,0 +1,10 @@
+version 1.0
+
+workflow foo {
+  input {
+    Array[File]+ inp
+  }
+  output {
+    Array[File]+ out = inp
+  }
+}

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -1088,4 +1088,11 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val retval = Main.compile(args.toVector)
     retval shouldBe a[Success]
   }
+
+  it should "compile a workflow with a native app with file output" taggedAs NativeTest in {
+    val path = pathFromBasename("bugs", "native_with_file_output.wdl")
+    val args = path.toString :: cFlags
+    val retval = Main.compile(args.toVector)
+    retval shouldBe a[Success]
+  }
 }


### PR DESCRIPTION
WDL requires that all output declarations have a value assigned, but in effect these values are ignored for native apps. This PR changes the WDL translator to not eval add default values to the IR `Parameter` instances for native app stub output parameters, because these can cause issues when they are copied.