### PR TITLE
APPS-324 Simplify release pipeline; add docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
         description: 'Release version'
         required: true
       should-run-tests:
-        description: 'Should run large integration tests (false/true; default: false)'
+        description: 'Should run large integration tests (false/true; default: true)'
         required: false
-        default: 'false'
+        default: 'true'
 
 jobs:
   run-release:
@@ -17,6 +17,35 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+
+      - name: Validate inputs
+        run: |
+          # Check if dxCompiler has already been released under this version
+          URL=https://github.com/dnanexus/dxCompiler/releases/download/${{ github.event.inputs.release-version }}/dxCompiler-${{ github.event.inputs.release-version }}.jar
+          RESP=$(curl -s -o /dev/null -w "%{http_code}" $URL)
+          echo "Response: $RESP"
+          if [ $RESP == 404 ]; then
+            echo "Version ${{ github.event.inputs.release-version }} not found; can continue with the release."
+          else
+            echo "Version ${{ github.event.inputs.release-version }} has already been released; please pick a different release version or delete the ${{ github.event.inputs.release-version }} release page and re-try."
+            exit 1
+          fi
+          # Check if application.conf files are already updated
+          CONF_FILES=(
+            ./executorWdl/src/main/resources/application.conf
+            ./core/src/main/resources/application.conf
+            ./executorCwl/src/main/resources/application.conf
+            ./compiler/src/main/resources/application.conf
+            ./executorCommon/src/main/resources/application.conf
+          )
+          for i in ${CONF_FILES[@]}; do
+            if [ $(grep -c \"${{ github.event.inputs.release-version }}\" $i) == 0 ]; then
+              echo "File $i is not updated with version ${{ github.event.inputs.release-version }}. Please update all application.conf files and re-try."
+              exit 1
+            else
+              echo "File $i is updated with version ${{ github.event.inputs.release-version }}. Continuing.."
+            fi
+          done
 
       - name: Install java
         uses: actions/setup-java@v1
@@ -51,42 +80,6 @@ jobs:
           #TODO: also remove the folder when the tests fail
           dx rmdir -r $FOLDER
 
-      - name: Extract release notes and set version in application.conf files
-        id: update-release
-        run: |
-          # Update the config files with the newest version
-          CONF_FILES=(
-              ./executorWdl/src/main/resources/application.conf
-              ./core/src/main/resources/application.conf
-              ./executorCwl/src/main/resources/application.conf
-              ./compiler/src/main/resources/application.conf
-              ./executorCommon/src/main/resources/application.conf
-          )
-          for i in ${CONF_FILES[@]}; do
-              sed -i 's/version.*$/version = "${{ github.event.inputs.release-version }}"/' $i
-          done
-          # Extract release notes for the release into a temporary (unpushed) file
-          # It is expected the RELEASE_NOTES.md has already an entry for the version being
-          # released. The section should start with '# <version>', e.g. # 2.0.0 2021-01-01
-          # The file will be read by the create-release step
-          RELEASE_NOTES_PATH="./release_notes_${{ github.event.inputs.release-version }}.md"
-          sed -n '/# ${{ github.event.inputs.release-version }}/,/##/p' RELEASE_NOTES.md |  sed '1d; $d' > $RELEASE_NOTES_PATH
-          echo ::set-output name=release-notes-path::$(echo "${RELEASE_NOTES_PATH}")
-
-      - name: Commit changes to application.conf files
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: 'Release ${{ github.event.inputs.release-version }}'
-          add: '[
-              "./executorWdl/src/main/resources/application.conf", 
-              "./core/src/main/resources/application.conf",
-              "./executorCwl/src/main/resources/application.conf",
-              "./compiler/src/main/resources/application.conf",
-              "./executorCommon/src/main/resources/application.conf"
-          ]'
-          push: false
-          tag: ${{ github.event.inputs.release-version }}
-
       - name: Run the release script
         env:
           DX_STAGING_RELEASE_TOKEN: ${{ secrets.DX_STAGING_RELEASE_TOKEN }}
@@ -100,6 +93,17 @@ jobs:
               --docker-user commandlinegirl \
               --docker-password $DOCKERHUB_TOKEN \
               --force
+
+      - name: Extract release notes
+        id: update-release
+        run: |
+          # Extract release notes for the release into a temporary (unpushed) file
+          # It is expected the RELEASE_NOTES.md has already an entry for the version being
+          # released. The section should start with '# <version>', e.g. # 1.0.0 2021-01-01
+          # The file will be read by the create-release step
+          RELEASE_NOTES_PATH="./release_notes_${{ github.event.inputs.release-version }}.md"
+          sed -n '/# ${{ github.event.inputs.release-version }}/,/##/p' RELEASE_NOTES.md |  sed '1d; $d' > $RELEASE_NOTES_PATH
+          echo ::set-output name=release-notes-path::$(echo "${RELEASE_NOTES_PATH}")
 
       - name: Create release entry
         id: create-release
@@ -127,17 +131,9 @@ jobs:
           asset_name: dxCompiler-${{ github.event.inputs.release-version }}.jar
           asset_content_type: application/jar
 
-      - name: Push tag to origin
+      - name: Create and push tag to origin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git tag ${{ github.event.inputs.release-version }}
           git push origin ${{ github.event.inputs.release-version }}
-
-        #- name: Rollback release if unsuccessfull
-        #if: ${{ cancelled() || failure() }}
-        #uses: author/action-rollback@stable
-        #with:
-        #  release_id: ${{ steps.create-release.outputs.id }}
-        #env:
-        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -207,10 +207,3 @@ dx clearenv
   this will take a while. It builds the release on staging, runs multi-region tests on staging (one test per region), builds on production, and creates an easy to use Docker image, which is pushed to DockerHub.
 - Update [releases](https://github.com/dnanexus/dxCompiler/releases) GitHub page, use the `Draft a new release` button, and upload the dxCompiler JAR file.
 
-### Post release
-
-- Update the version number in `*/src/main/resources/application.conf`. We don't want to mix the experimental release, with the old code.
-
-### Post release
-
-- Update the version number in `*/src/main/resources/application.conf`. We don't want to mix the experimental release, with the old code.

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -164,7 +164,26 @@ sbt keeps the cache of downloaded jar files in `${HOME}/.ivy2/cache`. For exampl
 
 ## Releasing a new version
 
-### Release check list
+### Releasing using Github Actions
+
+dxCompiler can be released from Github. The release pipeline (optionally) runs large integration tests, builds the release on staging, runs multi-region tests on staging (one test per region), builds on production, and creates a Docker image, which is pushed to DockerHub.
+
+Before starting the release:
+* Update [Release Notes](https://github.com/dnanexus/dxCompiler/blob/main/RELEASE_NOTES.md) with the version you'd like to create. The section corresponding to the new version should start with `## <version>`, e.g. `## 1.0.0 2020-01-01`; it will be extracted by the pipeline and used for the release page.
+* Update the following configuration files with the new release version (one version for all packages). You can use this [script](scripts/update_version.sh) for that.
+  * [compiler](https://github.com/dnanexus/dxCompiler/blob/main/compiler/src/main/resources/application.conf)
+  * [core](https://github.com/dnanexus/dxCompiler/blob/main/core/src/main/resources/application.conf)
+  * [executorCommon](https://github.com/dnanexus/dxCompiler/blob/main/executorCommon/src/main/resources/application.conf)
+  * [executorWdl](https://github.com/dnanexus/dxCompiler/blob/main/executorWdl/src/main/resources/application.conf)
+  * [executorCwl](https://github.com/dnanexus/dxCompiler/blob/main/executorCwl/src/main/resources/application.conf)
+* Push the changes to the `main` branch.
+* Run the release pipeline:
+  * Go to `Actions` > `dxCompiler Release (Staging and Prod)` and click `Run workflow` on the right side.
+  * Make sure the `main` branch is selected (default setting).
+  * Once finished, the pipeline will create a draft release page on GitHub.
+* Publish the draft [release](https://github.com/dnanexus-rnd/dxCompiler/releases). The compressed source code (in `zip` and `tar.gz`) will be added to the release page automatically.
+
+### Releasing manually
 
 - Make sure regression tests pass
 - Update [Release Notes](https://github.com/dnanexus/dxCompiler/blob/main/RELEASE_NOTES.md) and, if needed, README.md
@@ -173,9 +192,10 @@ sbt keeps the cache of downloaded jar files in `${HOME}/.ivy2/cache`. For exampl
   * [core](https://github.com/dnanexus/dxCompiler/blob/main/core/src/main/resources/application.conf)
   * [executorCommon](https://github.com/dnanexus/dxCompiler/blob/main/executorCommon/src/main/resources/application.conf)
   * [executorWdl](https://github.com/dnanexus/dxCompiler/blob/main/executorWdl/src/main/resources/application.conf)
+  * [executorCwl](https://github.com/dnanexus/dxCompiler/blob/main/executorCwl/src/main/resources/application.conf)
 
-is correct. It is used when building the release and creating the tag. Currently the version must be the same for all these packages.
-- Merge onto master branch, and make sure all [Github Actions](https://github.com/dnanexus/dxCompiler/actions) tests pass
+is correct (you can use this [script](scripts/update_version.sh) for that). It is used when building the release and creating the tag. Currently the version must be the same for all these packages.
+- Merge onto main branch, and make sure all [Github Actions](https://github.com/dnanexus/dxCompiler/actions) tests pass
 - Clean your `dx` environment because you'll be using limited-power tokens to run the release script. Do not mix them with your regular user token.
 ```
 dx clearenv
@@ -186,6 +206,10 @@ dx clearenv
   ```
   this will take a while. It builds the release on staging, runs multi-region tests on staging (one test per region), builds on production, and creates an easy to use Docker image, which is pushed to DockerHub.
 - Update [releases](https://github.com/dnanexus-rnd/dxCompiler/releases) GitHub page, use the `Draft a new release` button, and upload the dxCompiler JAR file.
+
+### Post release
+
+- Update the version number in `*/src/main/resources/application.conf`. We don't want to mix the experimental release, with the old code.
 
 ### Post release
 

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -169,8 +169,8 @@ sbt keeps the cache of downloaded jar files in `${HOME}/.ivy2/cache`. For exampl
 dxCompiler can be released from Github. The release pipeline (optionally) runs large integration tests, builds the release on staging, runs multi-region tests on staging (one test per region), builds on production, and creates a Docker image, which is pushed to DockerHub.
 
 Before starting the release:
-* Update [Release Notes](https://github.com/dnanexus/dxCompiler/blob/main/RELEASE_NOTES.md) with the version you'd like to create. The section corresponding to the new version should start with `## <version>`, e.g. `## 1.0.0 2020-01-01`; it will be extracted by the pipeline and used for the release page.
-* Update the following configuration files with the new release version (one version for all packages). You can use this [script](scripts/update_version.sh) for that.
+* Update [Release Notes](https://github.com/dnanexus/dxCompiler/blob/main/RELEASE_NOTES.md). The section corresponding to the new version should start with `## <version>`, e.g. `## 1.0.0 2020-01-01`; it will be used for the release page.
+* Update the configuration files with the new release version (one version for all packages). You can use this [script](../scripts/update_version.sh) for that.
   * [compiler](https://github.com/dnanexus/dxCompiler/blob/main/compiler/src/main/resources/application.conf)
   * [core](https://github.com/dnanexus/dxCompiler/blob/main/core/src/main/resources/application.conf)
   * [executorCommon](https://github.com/dnanexus/dxCompiler/blob/main/executorCommon/src/main/resources/application.conf)
@@ -181,7 +181,7 @@ Before starting the release:
   * Go to `Actions` > `dxCompiler Release (Staging and Prod)` and click `Run workflow` on the right side.
   * Make sure the `main` branch is selected (default setting).
   * Once finished, the pipeline will create a draft release page on GitHub.
-* Publish the draft [release](https://github.com/dnanexus-rnd/dxCompiler/releases). The compressed source code (in `zip` and `tar.gz`) will be added to the release page automatically.
+* Publish the draft [release](https://github.com/dnanexus/dxCompiler/releases). The compressed source code (in `zip` and `tar.gz`) will be added to the release page automatically.
 
 ### Releasing manually
 
@@ -194,7 +194,7 @@ Before starting the release:
   * [executorWdl](https://github.com/dnanexus/dxCompiler/blob/main/executorWdl/src/main/resources/application.conf)
   * [executorCwl](https://github.com/dnanexus/dxCompiler/blob/main/executorCwl/src/main/resources/application.conf)
 
-is correct (you can use this [script](scripts/update_version.sh) for that). It is used when building the release and creating the tag. Currently the version must be the same for all these packages.
+is correct (you can use this [script](../scripts/update_version.sh) for that). It is used when building the release and creating the tag. Currently the version must be the same for all these packages.
 - Merge onto main branch, and make sure all [Github Actions](https://github.com/dnanexus/dxCompiler/actions) tests pass
 - Clean your `dx` environment because you'll be using limited-power tokens to run the release script. Do not mix them with your regular user token.
 ```
@@ -205,7 +205,7 @@ dx clearenv
   ./scripts/build_all_releases.sh --staging-token XXX --production-token YYY --docker-user UUU --docker-password WWW
   ```
   this will take a while. It builds the release on staging, runs multi-region tests on staging (one test per region), builds on production, and creates an easy to use Docker image, which is pushed to DockerHub.
-- Update [releases](https://github.com/dnanexus-rnd/dxCompiler/releases) GitHub page, use the `Draft a new release` button, and upload the dxCompiler JAR file.
+- Update [releases](https://github.com/dnanexus/dxCompiler/releases) GitHub page, use the `Draft a new release` button, and upload the dxCompiler JAR file.
 
 ### Post release
 


### PR DESCRIPTION
* Builds a release directly from main, doesn't push any branch back
* Runs large integration tests by default
* Adds input validation
* Removes release entry rollback (so that the drafted page is kept in case of failure)