### PR TITLE
use wfName instead of wf.name in call to createCommonApplet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## in dev
+
+* Fixes common applet naming issue with complex nested workflows
+
 ## 2.3.0 23-02-2021
 
 * Adds `-separateOutputs` option to store output from each call in a separate folder

--- a/compiler/src/main/scala/dx/translator/wdl/CallableTranslator.scala
+++ b/compiler/src/main/scala/dx/translator/wdl/CallableTranslator.scala
@@ -997,7 +997,7 @@ case class CallableTranslator(wdlBundle: WdlBundle,
         }
         val closureOutputs: Vector[Parameter] = closureInputParams
         val (commonStage, commonApplet) =
-          createCommonApplet(wf.name,
+          createCommonApplet(wfName,
                              commonAppletInputs,
                              commonStageInputs,
                              inputOutputs ++ closureOutputs)


### PR DESCRIPTION
Using the wrong name causes applet name collisions, which causes compilation to fail for complex nested workflows.