### PR TITLE
APPS-419 handle optional call parameters with null arguments

### DIFF
--- a/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
+++ b/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
@@ -303,9 +303,14 @@ case class WdlWorkflowExecutor(docSource: FileNode,
         env: Map[String, (T, V)] = Map.empty
     ): Map[String, (T, V)] = {
       call.callee.input.flatMap {
-        case (name, (wdlType, _)) if call.inputs.contains(name) =>
-          val value = evaluateExpression(call.inputs(name), wdlType, env)
-          Some(name -> (wdlType, value))
+        case (name, (wdlType, optional)) if call.inputs.contains(name) =>
+          val optType = if (optional) {
+            TypeUtils.ensureOptional(wdlType)
+          } else {
+            TypeUtils.unwrapOptional(wdlType)
+          }
+          val value = evaluateExpression(call.inputs(name), optType, env)
+          Some(name -> (optType, value))
         case (name, (_, optional)) if optional =>
           logger.trace(s"no input for optional input ${name} to call ${call.fullyQualifiedName}")
           None

--- a/executorWdl/src/test/resources/bugs/opt_with_default.wdl
+++ b/executorWdl/src/test/resources/bugs/opt_with_default.wdl
@@ -1,0 +1,26 @@
+version 1.1
+
+workflow Test {
+  input {
+    Int? opt
+    File file
+  }
+
+  Int ref_size = ceil(size(file, "GB"))
+
+  call Foo {
+    input:
+      opt=opt,
+      non_opt=ref_size
+  }
+}
+
+task Foo {
+  input {
+    Int? opt = 20
+    Int non_opt
+  }
+  command <<<
+  echo ~{default="20" opt}
+  >>>
+}


### PR DESCRIPTION
Currently a workflow like the following fails with an error. This PR fixes the handling of null values specified for optional call parameters.

```wdl
version 1.1

workflow Test {
  input {
    Int? opt
  }

  call Foo {
    input: opt=opt
  }
}

task Foo {
  input {
    Int? opt = 20
  }
  command <<<
  echo ~{default="20" opt}
  >>>
}
```