### PR TITLE
APPS-422 - handle block inputs that are compound reference to private variables

### DIFF
--- a/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
@@ -42,17 +42,31 @@ object InputKind extends Enum {
 
 /**
   * A reference to a block input variable.
-  * @param name the variable name
-  * @param fieldName a field of the variable
+  * @param identifierParts the parts of the identifier name
+  * @param fieldName the fieldName within the call/object
+  *                  referred to by the identifier, if any
   * @param wdlType the variable's type
   * @param kind the variable's kind
   */
-case class WdlInputRef(name: String,
-                       fieldName: Option[String],
-                       wdlType: T,
-                       kind: InputKind.InputKind) {
-  // name.fieldName, if fieldName is defined, otherwise name
-  lazy val fullyQualifiedName: String = fieldName.map(field => s"${name}.${field}").getOrElse(name)
+private case class WdlInputRef(identifierParts: Vector[String],
+                               fieldName: Option[String],
+                               wdlType: T,
+                               kind: InputKind.InputKind) {
+  def identifier: String = identifierParts.mkString(".")
+
+  lazy val fullyQualifiedName: String = {
+    (identifierParts ++ fieldName.toVector).mkString(".")
+  }
+
+  /**
+    * Returns an Iterator over all the nested identifiers
+    * represented by this reference.
+    */
+  def nameIter: Iterator[String] = {
+    (identifierParts ++ fieldName.toVector).reverse.tails.collect {
+      case parts if parts.nonEmpty => parts.reverse.mkString(".")
+    }
+  }
 }
 
 object WdlUtils {
@@ -736,7 +750,7 @@ object WdlUtils {
     *   bar.left     Vector(('bar', None))         [bar is a Pair, withField = false]
     *   bar.left     Vector(('bar', Some('left'))) [bar is a Pair, withField = true]
     */
-  def getExpressionInputs(expr: TAT.Expr, withField: Boolean): Vector[WdlInputRef] = {
+  private def getExpressionInputs(expr: TAT.Expr, withField: Boolean): Vector[WdlInputRef] = {
     def inner(
         innerExpr: TAT.Expr
     ): Vector[WdlInputRef] = {
@@ -750,13 +764,12 @@ object WdlUtils {
         case _: TAT.ValueFile      => Vector.empty
         case _: TAT.ValueDirectory => Vector.empty
         case TAT.ExprIdentifier(id, wdlType, _) =>
-          Vector(
-              WdlInputRef(id,
-                          None,
-                          wdlType,
-                          if (TypeUtils.isOptional(wdlType)) InputKind.Optional
-                          else InputKind.Required)
-          )
+          val kind = if (TypeUtils.isOptional(wdlType)) {
+            InputKind.Optional
+          } else {
+            InputKind.Required
+          }
+          Vector(WdlInputRef(Vector(id), None, wdlType, kind))
         case TAT.ExprCompoundString(valArr, _, _) =>
           valArr.flatMap(elem => inner(elem))
         case TAT.ExprPair(l, r, _, _) =>
@@ -825,13 +838,12 @@ object WdlUtils {
                              fieldName,
                              wdlType,
                              _) if output.contains(fieldName) =>
-          Vector(
-              WdlInputRef(callId,
-                          Some(fieldName),
-                          wdlType,
-                          if (TypeUtils.isOptional(wdlType)) InputKind.Optional
-                          else InputKind.Required)
-          )
+          val kind = if (TypeUtils.isOptional(wdlType)) {
+            InputKind.Optional
+          } else {
+            InputKind.Required
+          }
+          Vector(WdlInputRef(Vector(callId), Some(fieldName), wdlType, kind))
         case TAT.ExprGetName(expr, fieldName, wdlType, _) =>
           // throw an exception if the reference is not valid
           TypeUtils.unwrapOptional(expr.wdlType) match {
@@ -847,7 +859,7 @@ object WdlUtils {
           val kind = if (TypeUtils.isOptional(wdlType)) InputKind.Optional else InputKind.Required
           inner(expr) match {
             case Vector(WdlInputRef(lhsName, Some(field), _, _)) if withField =>
-              Vector(WdlInputRef(s"${lhsName}.${field}", Some(fieldName), wdlType, kind))
+              Vector(WdlInputRef(lhsName :+ field, Some(fieldName), wdlType, kind))
             case Vector(WdlInputRef(lhsName, None, _, _)) if withField =>
               Vector(WdlInputRef(lhsName, Some(fieldName), wdlType, kind))
             case v if withField && v.nonEmpty =>
@@ -864,31 +876,6 @@ object WdlUtils {
     inner(expr)
   }
 
-  def getCallInputs(
-      call: TAT.Call
-  ): Vector[WdlInputRef] = {
-    // What the callee expects
-    call.callee.input.flatMap {
-      case (name: String, (_: T, optional: Boolean)) =>
-        (call.inputs.get(name), optional) match {
-          case (None, false) =>
-            // A required input that will have to be provided at runtime
-            Vector.empty
-          case (Some(expr), false) =>
-            // required input that is provided
-            getExpressionInputs(expr, withField = true)
-          case (None, true) =>
-            // a missing optional input, doesn't have to be provided
-            Vector.empty
-          case (Some(expr), true) =>
-            // an optional input
-            getExpressionInputs(expr, withField = true).map { ref =>
-              ref.copy(kind = InputKind.Optional)
-            }
-        }
-    }.toVector
-  }
-
   /**
     * Get all inputs and outputs for a block of statements.
     * @param elements the block elements
@@ -898,7 +885,6 @@ object WdlUtils {
       elements: Vector[TAT.WorkflowElement],
       withField: Boolean
   ): (Map[String, (T, InputKind.InputKind)], Map[String, TAT.OutputParameter]) = {
-    println(elements)
     def getOutputs(
         innerElements: Vector[TAT.WorkflowElement],
         innerWithField: Boolean
@@ -945,7 +931,22 @@ object WdlUtils {
         case v: TAT.PrivateVariable =>
           getExpressionInputs(v.expr, innerWithField)
         case call: TAT.Call =>
-          getCallInputs(call)
+          call.callee.input.flatMap {
+            case (name: String, (_: T, optional: Boolean)) =>
+              call.inputs
+                .get(name)
+                .map { expr =>
+                  val exprInputs = getExpressionInputs(expr, withField = true)
+                  if (optional) {
+                    exprInputs.map { ref =>
+                      ref.copy(kind = InputKind.Optional)
+                    }
+                  } else {
+                    exprInputs
+                  }
+                }
+                .getOrElse(Vector.empty)
+          }.toVector
         case cond: TAT.Conditional =>
           // get inputs for the conditional expression
           val exprInputs = getExpressionInputs(cond.expr, innerWithField)
@@ -960,7 +961,7 @@ object WdlUtils {
           // 'Computed' so it doesn't become a required input
           val scatterIdentifierRegexp = s"${scatter.identifier}([.\\[].+)?".r
           val bodyInputs = getInputs(scatter.body, innerWithField = true).map {
-            case ref if scatterIdentifierRegexp.matches(ref.name) =>
+            case ref if scatterIdentifierRegexp.matches(ref.identifier) =>
               ref.copy(kind = InputKind.Computed)
             case ref => ref
           }
@@ -978,8 +979,10 @@ object WdlUtils {
         throw new Exception(s"multiple outputs defined with the name ${name}: ${outputs}")
     }
 
-    // now convert the inputs, excluding any output variables
-    val allInputs = getInputs(elements, withField)
+    // now convert the inputs, filter out those that are in outputs,
+    // and check for collisions
+    val inputs = getInputs(elements, withField)
+      .filterNot(i => i.nameIter.exists(outputs.contains))
       .groupBy(_.fullyQualifiedName)
       .map {
         case (fqn, refs) if refs.toSet.size == 1 =>
@@ -997,10 +1000,6 @@ object WdlUtils {
           }
           fqn -> (priorityRefs.head.wdlType, priorityRefs.head.kind)
       }
-
-    val inputs = allInputs.flatMap {
-      case (fqn, (wdlType, kind)) if outputs.contains(fqn) =>
-    }
 
     (inputs, outputs)
   }

--- a/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
@@ -52,7 +52,7 @@ private case class WdlInputRef(identifierParts: Vector[String],
                                fieldName: Option[String],
                                wdlType: T,
                                kind: InputKind.InputKind) {
-  def identifier: String = identifierParts.mkString(".")
+  lazy val identifier: String = identifierParts.mkString(".")
 
   lazy val fullyQualifiedName: String = {
     (identifierParts ++ fieldName.toVector).mkString(".")

--- a/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
@@ -898,6 +898,7 @@ object WdlUtils {
       elements: Vector[TAT.WorkflowElement],
       withField: Boolean
   ): (Map[String, (T, InputKind.InputKind)], Map[String, TAT.OutputParameter]) = {
+    println(elements)
     def getOutputs(
         innerElements: Vector[TAT.WorkflowElement],
         innerWithField: Boolean
@@ -978,9 +979,8 @@ object WdlUtils {
     }
 
     // now convert the inputs, excluding any output variables
-    val inputs = getInputs(elements, withField)
+    val allInputs = getInputs(elements, withField)
       .groupBy(_.fullyQualifiedName)
-      .filterNot(i => outputs.contains(i._1))
       .map {
         case (fqn, refs) if refs.toSet.size == 1 =>
           fqn -> (refs.head.wdlType, refs.head.kind)
@@ -997,6 +997,10 @@ object WdlUtils {
           }
           fqn -> (priorityRefs.head.wdlType, priorityRefs.head.kind)
       }
+
+    val inputs = allInputs.flatMap {
+      case (fqn, (wdlType, kind)) if outputs.contains(fqn) =>
+    }
 
     (inputs, outputs)
   }

--- a/core/src/test/resources/bugs/apps-422.wdl
+++ b/core/src/test/resources/bugs/apps-422.wdl
@@ -22,9 +22,9 @@ workflow struct_test {
     input:
       answer = c.s
   }
-  
+
   output {
-    String out = test.out  
+    String out = test.out
   }
 }
 

--- a/core/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
+++ b/core/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
@@ -282,4 +282,12 @@ class WdlBlockTest extends AnyFlatSpec with Matchers {
           ) =>
     }
   }
+
+  it should "handle inputs that are nested references" in {
+    val subBlocks = getWorkflowBlocks("bugs", "apps-422.wdl")
+    subBlocks.head.inputs shouldBe Vector(
+        OptionalBlockInput("wf_input", WdlTypes.T_Optional(WdlTypes.T_String))
+    )
+  }
+
 }

--- a/core/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
+++ b/core/src/test/scala/dx/core/languages/wdl/WdlBlockTest.scala
@@ -289,5 +289,4 @@ class WdlBlockTest extends AnyFlatSpec with Matchers {
         OptionalBlockInput("wf_input", WdlTypes.T_Optional(WdlTypes.T_String))
     )
   }
-
 }

--- a/executorWdl/src/test/resources/bugs/apps-422.wdl
+++ b/executorWdl/src/test/resources/bugs/apps-422.wdl
@@ -1,0 +1,43 @@
+version 1.0
+
+struct Foo {
+  String s
+}
+
+workflow struct_test {
+  input {
+    String? wf_input
+  }
+
+  if (defined(wf_input)) {
+    Foo a = {"s": "no_input"}
+  }
+  if (defined(wf_input)) {
+    Foo b = {"s": "one_input"}
+  }
+
+  Foo c = select_first([a,b])
+
+  call test {
+    input:
+      answer = c.s
+  }
+  
+  output {
+    String out = test.out  
+  }
+}
+
+task test {
+  input {
+    String answer
+  }
+
+  command <<<
+    echo ~{answer}
+  >>>
+
+  output {
+    String out = read_string(stdout())
+  }
+}

--- a/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
+++ b/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
@@ -7,7 +7,7 @@ import dx.api._
 import dx.core.{Constants, ir}
 import dx.core.io.DxWorkerPaths
 import dx.core.ir.{ParameterLinkSerializer, ParameterLinkValue, Type, TypeSerde}
-import dx.core.languages.wdl.{OptionalBlockInput, WdlBlock, WdlBundle, WdlUtils}
+import dx.core.languages.wdl.{WdlBlock, WdlBundle, WdlUtils}
 import dx.executor.{JobMeta, WorkflowAction, WorkflowExecutor}
 import dx.util.{CodecUtils, FileSourceResolver, FileUtils, Logger}
 import dx.util.protocols.DxFileAccessProtocol

--- a/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
+++ b/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
@@ -1,14 +1,13 @@
 package dx.executor.wdl
 
 import java.nio.file.{Files, Path, Paths}
-
 import dx.Assumptions.isLoggedIn
 import dx.Tags.{EdgeTest, NativeTest}
 import dx.api._
 import dx.core.{Constants, ir}
 import dx.core.io.DxWorkerPaths
 import dx.core.ir.{ParameterLinkSerializer, ParameterLinkValue, Type, TypeSerde}
-import dx.core.languages.wdl.{WdlBlock, WdlBundle, WdlUtils}
+import dx.core.languages.wdl.{OptionalBlockInput, WdlBlock, WdlBundle, WdlUtils}
 import dx.executor.{JobMeta, WorkflowAction, WorkflowExecutor}
 import dx.util.{CodecUtils, FileSourceResolver, FileUtils, Logger}
 import dx.util.protocols.DxFileAccessProtocol
@@ -463,18 +462,6 @@ class WorkflowExecutorTest extends AnyFlatSpec with Matchers {
     }
     val args = wfSupport.WdlBlockContext.evaluateCallInputs(zincCall, Map.empty)
     args shouldBe Map.empty // ("a" -> (WdlTypes.T_Int, WdlValues.V_Int(3)))
-  }
-
-  it should "evaluate call input from private variable" in {
-    //val workerPaths = setup()
-    val path = pathFromBasename("bugs", "apps-422.wdl")
-    val wdlBundle = parse(path)
-    val wf: TAT.Workflow = wdlBundle.primaryCallable match {
-      case Some(wf: TAT.Workflow) => wf
-      case _                      => throw new Exception("unexpected")
-    }
-    val subBlocks = WdlBlock.createBlocks(wf.body)
-    println(subBlocks.head.inputs.mkString("\n"))
   }
 
   it should "expressions with structs" in {

--- a/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
+++ b/executorWdl/src/test/scala/dx/executor/wdl/WorkflowExecutorTest.scala
@@ -436,6 +436,18 @@ class WorkflowExecutorTest extends AnyFlatSpec with Matchers {
     args shouldBe Map.empty // ("a" -> (WdlTypes.T_Int, WdlValues.V_Int(3)))
   }
 
+  it should "evaluate call input from private variable" in {
+    //val workerPaths = setup()
+    val path = pathFromBasename("bugs", "apps-422.wdl")
+    val wdlBundle = parse(path)
+    val wf: TAT.Workflow = wdlBundle.primaryCallable match {
+      case Some(wf: TAT.Workflow) => wf
+      case _                      => throw new Exception("unexpected")
+    }
+    val subBlocks = WdlBlock.createBlocks(wf.body)
+    println(subBlocks.head.inputs.mkString("\n"))
+  }
+
   it should "expressions with structs" in {
     val workerPaths = setup()
     val path = pathFromBasename("frag_runner", "House.wdl")


### PR DESCRIPTION
If a `WdlBlock` contains a declaration of an object or struct type, it will yield a `WdlBlockInput` with a compound name. For example:

```wdl
Struct Foo {
  String s
}
workflow bar {
  Foo f = object { s: "hello" }
  String s = f.s
}
```

yields a `RequiredBlockInput("f.s")`

However, when this is evaluated, the environment only contains `f` so it results in a missing required input. This PR fixes this scenario by searching for the fully qualified name and all possible sub-names in the environment.