### PR TITLE
APPS-288 - fixes issue with using both streaming and non-streaming files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## in dev
 
 * Adds `-useManifests` option to generate applets and workflows whose inputs and outputs are manifest files
+* Fixes issue with using both streaming and non-streaming file inputs in the same task
 
 ## 2.3.1 03-03-2021
 

--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ val executorCwl = project
 
 lazy val dependencies =
   new {
-    val dxCommonVersion = "0.2.9"
+    val dxCommonVersion = "0.2.10"
     val dxApiVersion = "0.1.13"
     val dxFileAccessProtocolsVersion = "0.1.2"
     val wdlToolsVersion = "0.12.6"

--- a/compiler/src/main/resources/templates/applet_script.ssp
+++ b/compiler/src/main/resources/templates/applet_script.ssp
@@ -34,8 +34,8 @@
        # The download was ok, check file integrity on disk
        dx-download-agent inspect ${dxPathConfig.getDxdaManifestFile().toString}.bz2
 
-       # go back to work directory
-       cd ${dxPathConfig.getWorkDir().toString}
+       # go back to root directory
+       cd ${dxPathConfig.getRootDir().toString}
     fi
 
     # run dxfuse on a manifest of files. It will provide remote access

--- a/core/src/main/scala/dx/core/io/DxfuseManifest.scala
+++ b/core/src/main/scala/dx/core/io/DxfuseManifest.scala
@@ -26,12 +26,12 @@ case class DxfuseManifestBuilder(dxApi: DxApi) {
           throw new Exception(s"file ${dxFile} is not live")
         }
 
-        val parentDir = path.getParent.toString
+        val parentDir = path.getParent
         // remove the mountpoint from the directory. We need
         // paths that are relative to the mount point.
-        val mountDir = workerPaths.getDxfuseMountDir().toString
+        val mountDir = workerPaths.getDxfuseMountDir()
         assert(parentDir.startsWith(mountDir))
-        val relParentDir = s"/${parentDir.stripPrefix(mountDir)}"
+        val relParentDir = s"/${mountDir.relativize(parentDir)}"
 
         val desc = dxFile.describe()
         JsObject(

--- a/executorCommon/src/main/scala/dx/executor/TaskExecutor.scala
+++ b/executorCommon/src/main/scala/dx/executor/TaskExecutor.scala
@@ -239,6 +239,7 @@ abstract class TaskExecutor(jobMeta: JobMeta,
           jobMeta.workerPaths.getInputFilesDir(),
           existingPaths = localFilesToPath.values.toSet,
           separateDirsBySource = true,
+          createDirs = true,
           disambiguationDirLimit = TaskExecutor.MaxDisambiguationDirs
       )
     val downloadFileSourceToPath: Map[AddressableFileNode, Path] =
@@ -255,6 +256,7 @@ abstract class TaskExecutor(jobMeta: JobMeta,
           jobMeta.workerPaths.getDxfuseMountDir(),
           existingPaths = localFilesToPath.values.toSet,
           separateDirsBySource = true,
+          createDirs = false,
           disambiguationDirLimit = TaskExecutor.MaxDisambiguationDirs
       )
     val streamFileSourceToPath: Map[AddressableFileNode, Path] =

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -91,6 +91,7 @@ wdl_v1_list = [
     "nested_pairs",  # APPS-370
     "apps_378",
     "apps_384",
+    "diff_stream_and_download",  # APPS-288
 
     # manifests
     "simple_manifest",

--- a/test/bugs/diff_stream_and_download.wdl
+++ b/test/bugs/diff_stream_and_download.wdl
@@ -1,0 +1,20 @@
+version 1.0
+
+task diff_stream_and_download {
+  input {
+    File a
+    File b
+  }
+  parameter_meta {
+    a : "stream"
+  }
+  runtime {
+    docker: "ubuntu:16.04"
+  }
+  command {
+    diff ${a} ${b} | wc -l
+  }
+  output {
+    Int result = read_int(stdout())
+  }
+}

--- a/test/bugs/diff_stream_and_download_input.json
+++ b/test/bugs/diff_stream_and_download_input.json
@@ -1,0 +1,4 @@
+{
+  "diff_stream_and_download.a": "dx://file-FGqFGBQ0ffPPkYP19gBvFkZy",
+  "diff_stream_and_download.b": "dx://file-FGqFJ8Q0ffPGVz3zGy4FK02P"
+}


### PR DESCRIPTION
The issue was in the generated job script in the bash code block for dxda - it cd's to / at the beginning and then is supposed to cd back to the home directory at the end, but instead it was cd-ing to the work dir. This only causes an issue if dxfuse is also used, because it tries to source environment, which is in the home dir. The error was not showing up in the log because we pipe the output from `source environment` to /dev/null to avoid leaking the token to the logs, so it was also swallowing the error message.

Also fixes the parent directory name written to the dxfuse manifest (removes the extra leading '/').

Also updates to dxCommon 0.2.10 which fixes another issue - the LocalizationDisambiguator was creating directories in the dxfuse mount point, which is wrong behavior, but I guess dxfuse doesn't complain as long as the directory is empty.