### PR TITLE
APPS-456 fixes issue with having a scatter as the first workflow element

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Adds `-useManifests` option to generate applets and workflows whose inputs and outputs are manifest files
 * Fixes issue with using both streaming and non-streaming file inputs in the same task
+* Fixes issue with scatter as the first element of a workflow
 
 ## 2.3.1 03-03-2021
 

--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -24,7 +24,7 @@ fi
 dx download ${bashDollar}{AWS_CREDENTIALS} -o ${bashDollar}{HOME}/.aws/credentials
 
 # install the aws client
-apt install -y awscli
+apt update -y && apt install -y awscli
 
 # get the password from the aws client
 password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REGION})

--- a/compiler/src/main/scala/dx/translator/wdl/CallableTranslator.scala
+++ b/compiler/src/main/scala/dx/translator/wdl/CallableTranslator.scala
@@ -537,12 +537,12 @@ case class CallableTranslator(wdlBundle: WdlBundle,
         val (statementClosureInputs, statementClosureOutputs) =
           WdlUtils.getClosureInputsAndOutputs(statements, withField = true)
         // create block inputs for the closure inputs
-        val inputs = WdlBlockInput.create(statementClosureInputs)
+        val allInputs = WdlBlockInput.create(statementClosureInputs)
         val outputs = statementClosureOutputs.values.toVector
         // collect the sub-block inputs that are not workflow inputs or outputs -
         // these are additional inputs from outside the block that need to be
         // supplied as workflow inputs
-        val externalNames = (inputs.map(_.name) ++ outputs.map(_.name)).toSet
+        val externalNames = (allInputs.map(_.name) ++ outputs.map(_.name)).toSet
         // TODO: will there ever be block inputs that are not included in
         //  statementClosureInputs?
         val closureInputs = subBlocks.flatMap { block =>
@@ -551,6 +551,10 @@ case class CallableTranslator(wdlBundle: WdlBundle,
               blockInput.name -> (blockInput.wdlType, blockInput.kind)
           }
         }.toMap
+        val inputs = allInputs.filter {
+          case _: ComputedBlockInput => false
+          case _                     => true
+        }
         logger.trace(
             s"""|compileNestedBlock
                 |    inputs = $inputs

--- a/compiler/src/test/resources/bugs/scatter_inside_if.wdl
+++ b/compiler/src/test/resources/bugs/scatter_inside_if.wdl
@@ -1,0 +1,26 @@
+version 1.0
+
+workflow test {
+  input {
+    Array[String]? str_input
+  }
+
+  if (defined(str_input)) {
+    scatter (item in select_first([str_input])) {
+      call show {
+        input: a = item
+      }
+    }
+    String abc = "def"
+  }
+}
+
+task show {
+  input {
+    String? a
+  }
+  command {
+    echo "~{a}"
+  }
+  output {}
+}

--- a/compiler/src/test/scala/dx/translator/TranslatorTest.scala
+++ b/compiler/src/test/scala/dx/translator/TranslatorTest.scala
@@ -1522,4 +1522,10 @@ Main.compile(args.toVector) shouldBe a[SuccessfulCompileIR]
     val args = path.toString :: cFlags
     Main.compile(args.toVector) shouldBe a[SuccessfulCompileIR]
   }
+
+  it should "translate a workflow with scatter inside conditional" in {
+    val path = pathFromBasename("bugs", "scatter_inside_if.wdl")
+    val args = path.toString :: cFlags
+    Main.compile(args.toVector) shouldBe a[SuccessfulCompileIR]
+  }
 }

--- a/executorWdl/src/test/scala/dx/executor/wdl/TaskExecutorTest.scala
+++ b/executorWdl/src/test/scala/dx/executor/wdl/TaskExecutorTest.scala
@@ -314,7 +314,7 @@ class TaskExecutorTest extends AnyFlatSpec with Matchers {
               // block here until the file is closed
               if (!Iterator.range(0, 10).exists { i =>
                     if (i > 0) {
-                      Thread.sleep(1000)
+                      Thread.sleep(2000)
                     }
                     val desc =
                       dxApi.fileDescribe(manifestFile.id,
@@ -324,7 +324,7 @@ class TaskExecutorTest extends AnyFlatSpec with Matchers {
                       case _                        => false
                     }
                   }) {
-                throw new Exception("manifest file did not close within 10 seconds")
+                throw new Exception("manifest file did not close within 20 seconds")
               }
               val manifest =
                 Manifest.parse(new String(jobMeta.dxApi.downloadBytes(manifestFile)).parseJson)


### PR DESCRIPTION
Computed inputs (i.e. scatter variables) need to be excluded from workflow inputs.