### PR TITLE
APPS-462 fix issue with scatter collect when using manifests

### DIFF
--- a/compiler/src/main/resources/templates/applet_script.ssp
+++ b/compiler/src/main/resources/templates/applet_script.ssp
@@ -18,17 +18,17 @@
        # run the download agent, and store the return code; do not exit on error.
        # we need to run it from the root directory, because it uses relative paths.
        cd /
-       rc=0
-       dx-download-agent download ${dxPathConfig.getDxdaManifestFile().toString}.bz2 || rc=${bashDollar}? && true
+       dxda_error_code=0
+       dx-download-agent download ${dxPathConfig.getDxdaManifestFile().toString}.bz2 || dxda_error_code=${bashDollar}? && true
 
        # if there was an error during download, print out the download log
-       if [[ ${bashDollar}rc != 0 ]]; then
-           echo "download agent failed rc=${bashDollar}rc"
+       if [[ ${bashDollar}dxda_error_code != 0 ]]; then
+           echo "download agent failed rc=${bashDollar}dxda_error_code"
            if [[ -e ${dxPathConfig.getDxdaManifestFile().toString}.bz2.download.log ]]; then
               echo "The download log is:"
               cat ${dxPathConfig.getDxdaManifestFile().toString}.bz2.download.log
            fi
-           exit ${bashDollar}rc
+           exit ${bashDollar}dxda_error_code
        fi
 
        # The download was ok, check file integrity on disk
@@ -55,8 +55,8 @@
 
        # run dxfuse so that it will not exit after the bash script exists.
        echo "mounting dxfuse on ${dxPathConfig.getDxfuseMountDir().toString}"
-       dxfuse -readOnly ${dxPathConfig.getDxfuseMountDir().toString} ${dxPathConfig.getDxfuseManifestFile().toString}
-       dxfuse_err_code=${bashDollar}?
+       dxfuse_err_code=0
+       dxfuse -readOnly ${dxPathConfig.getDxfuseMountDir().toString} ${dxPathConfig.getDxfuseManifestFile().toString} || dxfuse_err_code=${bashDollar}? && true
 
        if [[ ${bashDollar}dxfuse_err_code != 0 ]]; then
            echo "error starting dxfuse, rc=${bashDollar}dxfuse_err_code"
@@ -66,7 +66,7 @@
            if [[ -f ${bashDollar}dxfuse_log ]]; then
                cat ${bashDollar}dxfuse_log
            fi
-           exit 1
+           exit ${bashDollar}dxfuse_err_code
        fi
 
        echo ""

--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -47,5 +47,5 @@ while [[ ${bashDollar}i -le 5 ]]; do
 done
 
 # cleanup
-apt autoclean && apt purge awscli
+apt autoclean -y && apt purge -y awscli
 rm -rf ${bashDollar}{HOME}/.aws

--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -30,11 +30,14 @@ apt update -y && apt install -y awscli
 password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REGION})
 
 # Log into docker. Retry several times.
-set -e
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # disable echo to avoid logging password
+    # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
+    set +e
     echo ${bashDollar}{password} | docker login ${bashDollar}{DOCKER_REGISTRY} --username AWS --password-stdin
     rc=${bashDollar}?
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -42,7 +45,6 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
-set +e
 
 # cleanup
 apt autoclean && apt purge awscli

--- a/compiler/src/main/resources/templates/generic_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/generic_docker_preamble.ssp
@@ -22,11 +22,14 @@ dx download ${bashDollar}{DOCKER_CREDENTIALS} -o ${bashDollar}{HOME}/docker_cred
 creds=${bashDollar}(cat ${bashDollar}{HOME}/docker_credentials)
 
 # Log into docker. Retry several times.
-set -e
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # disable echo to avoid logging password
+    # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
+    set +e
     echo ${bashDollar}{creds} | docker login ${bashDollar}{DOCKER_REGISTRY} -u ${bashDollar}{DOCKER_USERNAME} --password-stdin
     rc=${bashDollar}?
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -34,6 +37,5 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
-set +e
 
 rm -f ${bashDollar}{HOME}/docker_credentials

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -567,9 +567,9 @@ task bwa_mem {
   ])
 
   command <<<
-  set -eux
+  set -euxo pipefail
   tar xzvf ~{genome_index_tgz}
-  bwa mem \
+  /usr/gitc/bwa mem \
     -M \
     -t ~{cpu} \
     -R "~{actual_read_group}" \

--- a/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
+++ b/executorWdl/src/main/scala/dx/executor/wdl/WdlWorkflowExecutor.scala
@@ -1019,7 +1019,7 @@ case class WdlWorkflowExecutor(docSource: FileNode,
           throw new RuntimeException(s"invalid block ${block}")
       }
 
-      val (manifestId, executionName, childOutputs) =
+      val (manifestId, execName, childOutputs) =
         if (jobMeta.useManifests) {
           // each job has an output manifest - we need to download them all
           childExecutions
@@ -1074,7 +1074,7 @@ case class WdlWorkflowExecutor(docSource: FileNode,
         case (name, irType) =>
           val arrayType = TArray(irType)
           val nameEncoded = Parameter.encodeDots(name)
-          val longNameEncoded = executionName.map(e => Parameter.encodeDots(s"${e}.${name}"))
+          val longNameEncoded = execName.map(e => Parameter.encodeDots(s"${e}.${name}"))
           val arrayValue = childOutputs.flatMap { outputs =>
             val jsValue = outputs.get(nameEncoded).orElse(longNameEncoded.flatMap(outputs.get))
             (irType, jsValue) match {

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -96,7 +96,7 @@ wdl_v1_list = [
     # manifests
     "simple_manifest",
     "complex_manifest",
-    "view_and_count"
+    "view_and_count_manifest"
 ]
 
 # docker image tests

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -96,6 +96,7 @@ wdl_v1_list = [
     # manifests
     "simple_manifest",
     "complex_manifest",
+    "view_and_count"
 ]
 
 # docker image tests

--- a/test/manifest/view_and_count_manifest.wdl
+++ b/test/manifest/view_and_count_manifest.wdl
@@ -1,0 +1,49 @@
+version 1.0
+
+workflow view_and_count {
+  input {
+    File bam
+  }
+
+  call slice_bam {
+    input: bam = bam
+  }
+
+  scatter (slice in slice_bam.slices) {
+    call count_bam {
+      input: bam = slice
+    }
+  }
+
+  output {
+    Array[Int] counts = count_bam.count
+  }
+}
+
+task slice_bam {
+  input {
+    File bam
+  }
+
+  command <<<
+    split -l 1 -a 1 ~{bam} bam
+  >>>
+
+  output {
+    Array[File] slices = glob("bam*")
+  }
+}
+
+task count_bam {
+  input {
+    File bam
+  }
+
+  command <<<
+    wc -l ~{bam} | cut -d" " -f 1
+  >>>
+
+  output {
+    Int count = read_int(stdout())
+  }
+}

--- a/test/manifest/view_and_count_manifest_input.json
+++ b/test/manifest/view_and_count_manifest_input.json
@@ -1,0 +1,5 @@
+{
+  "view_and_count.input_manifest___": {
+    "bam": "dx://file-G192BPQ0yzZxQ8QY6kGJXxv2"
+  }
+}


### PR DESCRIPTION
The output manifest keys may be prefixed with the execution name, so if the short name is not present we need to try with the long name.