### PR TITLE
don't log docker passwords

### DIFF
--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -30,11 +30,14 @@ apt update -y && apt install -y awscli
 password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REGION})
 
 # Log into docker. Retry several times.
-set -e
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # disable echo to avoid logging password
+    # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
+    set +e
     echo ${bashDollar}{password} | docker login ${bashDollar}{DOCKER_REGISTRY} --username AWS --password-stdin
     rc=${bashDollar}?
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -42,7 +45,6 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
-set +e
 
 # cleanup
 apt autoclean && apt purge awscli

--- a/compiler/src/main/resources/templates/generic_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/generic_docker_preamble.ssp
@@ -22,11 +22,14 @@ dx download ${bashDollar}{DOCKER_CREDENTIALS} -o ${bashDollar}{HOME}/docker_cred
 creds=${bashDollar}(cat ${bashDollar}{HOME}/docker_credentials)
 
 # Log into docker. Retry several times.
-set -e
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # disable echo to avoid logging password
+    # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
+    set +e
     echo ${bashDollar}{creds} | docker login ${bashDollar}{DOCKER_REGISTRY} -u ${bashDollar}{DOCKER_USERNAME} --password-stdin
     rc=${bashDollar}?
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -34,6 +37,5 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
-set +e
 
 rm -f ${bashDollar}{HOME}/docker_credentials


### PR DESCRIPTION
this change avoids echoing docker passwords to the job log