### PR TITLE
use static AWS client, don't echo password

### DIFF
--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -24,7 +24,7 @@ fi
 dx download ${bashDollar}{AWS_CREDENTIALS} -o ${bashDollar}{HOME}/.aws/credentials
 
 # disable echo to avoid logging password
-set +e
+set +x
 
 # install the aws client to /usr/local/bin
 unzip /usr/bin/awscliv2.zip && ./aws/install && rm -Rf ./aws
@@ -35,10 +35,12 @@ password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REG
 # Log into docker. Retry several times.
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # don't exit if docker command fails - retry instead
+    set +e
     # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
     echo ${bashDollar}{password} | docker login ${bashDollar}{DOCKER_REGISTRY} --username AWS --password-stdin
     rc=${bashDollar}?
-
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -47,7 +49,7 @@ while [[ ${bashDollar}i -le 5 ]]; do
     echo "retry docker login (${bashDollar}i)"
 done
 
-set -e
+set -x
 
 # cleanup
 apt autoclean -y && apt purge -y awscli

--- a/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/ecr_docker_preamble.ssp
@@ -23,8 +23,11 @@ if [[ ${bashDollar}num_lines != 1 ]]; then
 fi
 dx download ${bashDollar}{AWS_CREDENTIALS} -o ${bashDollar}{HOME}/.aws/credentials
 
-# install the aws client
-apt update -y && apt install -y awscli
+# disable echo to avoid logging password
+set +e
+
+# install the aws client to /usr/local/bin
+unzip /usr/bin/awscliv2.zip && ./aws/install && rm -Rf ./aws
 
 # get the password from the aws client
 password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REGION})
@@ -32,12 +35,10 @@ password=${bashDollar}(aws ecr get-login-password --region ${bashDollar}{AWS_REG
 # Log into docker. Retry several times.
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
-    # disable echo to avoid logging password
     # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
-    set +e
     echo ${bashDollar}{password} | docker login ${bashDollar}{DOCKER_REGISTRY} --username AWS --password-stdin
     rc=${bashDollar}?
-    set -e
+
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -45,6 +46,8 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
+
+set -e
 
 # cleanup
 apt autoclean -y && apt purge -y awscli

--- a/compiler/src/main/resources/templates/generic_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/generic_docker_preamble.ssp
@@ -19,17 +19,17 @@ if [[ ${bashDollar}num_lines != 1 ]]; then
     exit 1
 fi
 dx download ${bashDollar}{DOCKER_CREDENTIALS} -o ${bashDollar}{HOME}/docker_credentials
+
+# disable echo to avoid logging password
+set +e
 creds=${bashDollar}(cat ${bashDollar}{HOME}/docker_credentials)
 
 # Log into docker. Retry several times.
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
-    # disable echo to avoid logging password
     # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
-    set +e
     echo ${bashDollar}{creds} | docker login ${bashDollar}{DOCKER_REGISTRY} -u ${bashDollar}{DOCKER_USERNAME} --password-stdin
     rc=${bashDollar}?
-    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -37,5 +37,7 @@ while [[ ${bashDollar}i -le 5 ]]; do
     sleep 3
     echo "retry docker login (${bashDollar}i)"
 done
+
+set -e
 
 rm -f ${bashDollar}{HOME}/docker_credentials

--- a/compiler/src/main/resources/templates/generic_docker_preamble.ssp
+++ b/compiler/src/main/resources/templates/generic_docker_preamble.ssp
@@ -21,15 +21,18 @@ fi
 dx download ${bashDollar}{DOCKER_CREDENTIALS} -o ${bashDollar}{HOME}/docker_credentials
 
 # disable echo to avoid logging password
-set +e
+set +x
 creds=${bashDollar}(cat ${bashDollar}{HOME}/docker_credentials)
 
 # Log into docker. Retry several times.
 i=0
 while [[ ${bashDollar}i -le 5 ]]; do
+    # don't exit if docker command fails - retry instead
+    set +e
     # TODO: use credential helper instead https://docs.docker.com/engine/reference/commandline/login/
     echo ${bashDollar}{creds} | docker login ${bashDollar}{DOCKER_REGISTRY} -u ${bashDollar}{DOCKER_USERNAME} --password-stdin
     rc=${bashDollar}?
+    set -e
     if [[ ${bashDollar}rc == 0 ]]; then
         break
     fi
@@ -38,6 +41,6 @@ while [[ ${bashDollar}i -le 5 ]]; do
     echo "retry docker login (${bashDollar}i)"
 done
 
-set -e
+set -x
 
 rm -f ${bashDollar}{HOME}/docker_credentials

--- a/scripts/bundled_dependencies.json
+++ b/scripts/bundled_dependencies.json
@@ -1,6 +1,7 @@
 {
   "dxda": "v0.5.4",
   "dxfuse": "v0.24.0",
+  "awscli": "2.1.32",
   "execDepends": {
     "cwl": [
       {

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -164,6 +164,26 @@ def _download_dxfuse_to_resources(top_dir, dxfuse_version):
     return dxfuse_exe
 
 
+def _download_awscli_to_resources(top_dir, awscli_version):
+    awscli_dir = os.path.join(top_dir, "applet_resources", "awscli", awscli_version)
+    awscli_zip = os.path.join(awscli_dir, "awscliv2.zip")
+
+    if not (os.path.exists(awscli_zip)):
+        os.makedirs(awscli_dir, exist_ok=True)
+        info("downloading awscli {} to {}".format(awscli_version, awscli_zip))
+        try:
+            subprocess.check_call([
+                "wget",
+                "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{}.zip".format(awscli_version),
+                "-O",
+                awscli_zip])
+        except subprocess.CalledProcessError as e:
+            print(e.stdout)
+            print(e.stderr)
+            raise e
+
+    return awscli_zip
+
 def _create_asset_spec(version_id, top_dir, language, dependencies=None):
     # TODO: update to 20.04 - just waiting for staging to catch up to prod
     exec_depends = [
@@ -321,7 +341,9 @@ def build(project, folder, version_id, top_dir, path_dict, dependencies=None, fo
         dxda_exe = _download_dxda_into_resources(top_dir, dependencies["dxda"])
         # get a copy of the dxfuse executable
         dxfuse_exe = _download_dxfuse_to_resources(top_dir, dependencies["dxfuse"])
-        resources = [dxda_exe, dxfuse_exe]
+        # get a copy of awscliv2
+        awscli_zip = _download_awscli_to_resources(top_dir, dependencies["awscli"])
+        resources = [dxda_exe, dxfuse_exe, awscli_zip]
 
         # Create a configuration file
         _gen_config_file(top_dir, path_dict)


### PR DESCRIPTION
There are still intermittent issues with installing the AWS CLI at runtime. This PR packages the AWS CLI installer with the executor. Also fixes echoing of passwords to the log (for real this time).