### PR TITLE
APPS-534 poll analysis on reorg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,9 +119,9 @@ val executorCwl = project
 
 lazy val dependencies =
   new {
-    val dxCommonVersion = "0.2.10"
-    val dxApiVersion = "0.1.13"
-    val dxFileAccessProtocolsVersion = "0.1.2"
+    val dxCommonVersion = "0.2.11"
+    val dxApiVersion = "0.1.15"
+    val dxFileAccessProtocolsVersion = "0.1.4"
     val wdlToolsVersion = "0.12.7"
     val cwlScalaVersion = "0.3.4"
     val typesafeVersion = "1.3.3"

--- a/doc/CustomReorgAppletExample.md
+++ b/doc/CustomReorgAppletExample.md
@@ -77,7 +77,7 @@ def main(reorg_conf___=None, reorg_status___=None):
     while True:
         analysis_desc = dxpy.describe(analysis_id)
         if analysis_desc.get("dependsOn"):
-            time.sleep(1)
+            time.sleep(3)
         else:
             break
             

--- a/doc/CustomReorgAppletExample.md
+++ b/doc/CustomReorgAppletExample.md
@@ -59,7 +59,7 @@ The applet code does the following.
 
 ```
 import json
-
+import time
 import dxpy
 
 @dxpy.entry_point('main')
@@ -73,7 +73,15 @@ def main(reorg_conf___=None, reorg_status___=None):
 
     # find the output stage of the current analysis
     analysis_id = dxpy.describe(dxpy.JOB_ID)["analysis"]
-    stages = dxpy.describe(analysis_id)["stages"]
+    # describe the analysis in a loop until dependsOn is empty
+    while True:
+        analysis_desc = dxpy.describe(analysis_id)
+        if analysis_desc.get("dependsOn"):
+            time.sleep(1)
+        else:
+            break
+            
+    stages = analysis_desc["stages"]
 
     # retrieve the dictionary containing outputs, where key is the name of output and value is the link to the file.
     output_map = [x['execution']['output'] for x in stages if x['id'] == 'stage-outputs'][0]

--- a/doc/CustomReorgAppletExample.md
+++ b/doc/CustomReorgAppletExample.md
@@ -59,7 +59,6 @@ The applet code does the following.
 
 ```
 import json
-import time
 import dxpy
 
 @dxpy.entry_point('main')

--- a/doc/CustomReorgAppletExample.md
+++ b/doc/CustomReorgAppletExample.md
@@ -74,12 +74,14 @@ def main(reorg_conf___=None, reorg_status___=None):
     # find the output stage of the current analysis
     analysis_id = dxpy.describe(dxpy.JOB_ID)["analysis"]
     # describe the analysis in a loop until dependsOn is empty
+    # or contains only this reorg job's ID
     while True:
         analysis_desc = dxpy.describe(analysis_id)
-        if analysis_desc.get("dependsOn"):
-            time.sleep(3)
-        else:
+        depends_on = analysis_desc.get("dependsOn")
+        if not depends_on or depends_on == [dxpy.JOB_ID]:
             break
+        else:
+            time.sleep(3)
             
     stages = analysis_desc["stages"]
 

--- a/doc/CustomReorgAppletExample.md
+++ b/doc/CustomReorgAppletExample.md
@@ -73,16 +73,7 @@ def main(reorg_conf___=None, reorg_status___=None):
 
     # find the output stage of the current analysis
     analysis_id = dxpy.describe(dxpy.JOB_ID)["analysis"]
-    # describe the analysis in a loop until dependsOn is empty
-    # or contains only this reorg job's ID
-    while True:
-        analysis_desc = dxpy.describe(analysis_id)
-        depends_on = analysis_desc.get("dependsOn")
-        if not depends_on or depends_on == [dxpy.JOB_ID]:
-            break
-        else:
-            time.sleep(3)
-            
+    analysis_desc = dxpy.describe(analysis_id)
     stages = analysis_desc["stages"]
 
     # retrieve the dictionary containing outputs, where key is the name of output and value is the link to the file.

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -877,8 +877,6 @@ it may misplace or outright delete files. The applet:
 3. has to be careful about inputs that are *also* outputs. Normally, these should not be moved.
 4. should use bulk object operations, so as not to overload the API server.
 
-You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 3 seconds between iterations), and exit the loop when the `dependsOn` field returns an array that contains exactly one item - the ID of the reorg job itself. See the [example](CustomReorgAppletExample.md).  
-
 ## Adding config-file based reorg applet at compilation time
 
 In addition to using `--reorg` flag to add the reorg stage, you may also add a custom reorganization applet that takes an optional input by declaring a "customReorgAttributes" object in the JSON file used as parameter with `-extras`

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -877,6 +877,8 @@ it may misplace or outright delete files. The applet:
 3. has to be careful about inputs that are *also* outputs. Normally, these should not be moved.
 4. should use bulk object operations, so as not to overload the API server.
 
+You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 1 second between iterations), and exit the loop when the `dependsOn` field of the analysis is an empty array.  
+
 ## Adding config-file based reorg applet at compilation time
 
 In addition to using `--reorg` flag to add the reorg stage, you may also add a custom reorganization applet that takes an optional input by declaring a "customReorgAttributes" object in the JSON file used as parameter with `-extras`

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -877,7 +877,7 @@ it may misplace or outright delete files. The applet:
 3. has to be careful about inputs that are *also* outputs. Normally, these should not be moved.
 4. should use bulk object operations, so as not to overload the API server.
 
-You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 3 seconds between iterations), and exit the loop when the `dependsOn` field of the analysis is an empty array.  
+You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 3 seconds between iterations), and exit the loop when the `dependsOn` field returns an array that contains exactly one item - the ID of the reorg job itself. See the [example](CustomReorgAppletExample.md).  
 
 ## Adding config-file based reorg applet at compilation time
 

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -877,7 +877,7 @@ it may misplace or outright delete files. The applet:
 3. has to be careful about inputs that are *also* outputs. Normally, these should not be moved.
 4. should use bulk object operations, so as not to overload the API server.
 
-You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 1 second between iterations), and exit the loop when the `dependsOn` field of the analysis is an empty array.  
+You must also be aware that the analysis information is updated in the platform's database asynchronously, so the result of calling `dx describe` on the analysis may not be up-to-date. The most reliable method for making sure you have an up-to-date analysis description is to call `dx describe` in a loop (waiting at least 3 seconds between iterations), and exit the loop when the `dependsOn` field of the analysis is an empty array.  
 
 ## Adding config-file based reorg applet at compilation time
 

--- a/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
+++ b/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
@@ -208,7 +208,7 @@ abstract class WorkflowExecutor[B <: Block[B]](jobMeta: JobMeta, separateOutputs
       )
       .collectFirstDefined {
         case a if a.dependsOn.exists(_.nonEmpty) =>
-          Thread.sleep(1000)
+          Thread.sleep(3000)
           None
         case a => Some(a)
       }

--- a/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
+++ b/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
@@ -199,7 +199,7 @@ abstract class WorkflowExecutor[B <: Block[B]](jobMeta: JobMeta, separateOutputs
   }
 
   private def getAnalysisOutputFiles(analysis: DxAnalysis): Map[String, DxFile] = {
-    // the analysis is updated ansynchronously, so we need to check the dependsOn field
+    // the analysis is updated asynchronously, so we need to check the dependsOn field
     // to determine if it is still waiting on the output of a previous stage before we
     // can proceed with the reorg
     val desc = Iterator

--- a/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
+++ b/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
@@ -8,6 +8,7 @@ import dx.core.Constants
 import dx.core.ir.{Block, ExecutableLink, Parameter, ParameterLink, Type, TypeSerde, Value}
 import spray.json._
 import dx.util.{Enum, TraceLevel}
+import dx.util.CollectionUtils.IterableOnceExtensions
 
 object WorkflowAction extends Enum {
   type WorkflowAction = Value
@@ -198,7 +199,20 @@ abstract class WorkflowExecutor[B <: Block[B]](jobMeta: JobMeta, separateOutputs
   }
 
   private def getAnalysisOutputFiles(analysis: DxAnalysis): Map[String, DxFile] = {
-    val desc = analysis.describe(Set(Field.Input, Field.Output))
+    // the analysis is updated ansynchronously, so we need to check the dependsOn field
+    // to determine if it is still waiting on the output of a previous stage before we
+    // can proceed with the reorg
+    val desc = Iterator
+      .continually(
+          analysis.describeNoCache(Set(Field.Input, Field.Output, Field.DependsOn))
+      )
+      .collectFirstDefined {
+        case a if a.dependsOn.exists(_.nonEmpty) =>
+          Thread.sleep(1000)
+          None
+        case a => Some(a)
+      }
+      .get
     val fileOutputs: Set[DxFile] = DxFile.findFiles(dxApi, desc.output.get).toSet
     val fileInputs: Set[DxFile] = DxFile.findFiles(dxApi, desc.input.get).toSet
     val analysisFiles: Vector[DxFile] = (fileOutputs -- fileInputs).toVector

--- a/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
+++ b/executorCommon/src/main/scala/dx/executor/WorkflowExecutor.scala
@@ -208,9 +208,8 @@ abstract class WorkflowExecutor[B <: Block[B]](jobMeta: JobMeta, separateOutputs
       )
       .collectFirstDefined { a =>
         a.dependsOn match {
-          case Some(Vector(jobMeta.jobId)) => Some(a)
-          case Some(Vector())              => Some(a)
-          case None                        => Some(a)
+          case Some(Vector(jobId)) if jobId == jobMeta.jobId => Some(a)
+          case None | Some(Vector())                         => Some(a)
           case _ =>
             Thread.sleep(3000)
             None


### PR DESCRIPTION
The analysis is updated in the backend asynchronously, so we need to check the `dependsOn` field to determine if it is still waiting on the output of a previous stage before we can proceed with the reorg.

This PR also updates to the latest dxScala dependencies.