### PR TITLE
APPS-512 - add private variables from outer scope to env when computing inputs of nested scatters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## in develop
+
+* Fixes issue with nested scatters that reference private variables from outer scopes
+
 ## 2.4.1 03-25-2021
 
 * Fixes AWS ECR issues: bundles AWS CLI with executor rather than installing at runtime

--- a/compiler/src/test/resources/nested/nested_scatter.wdl
+++ b/compiler/src/test/resources/nested/nested_scatter.wdl
@@ -8,7 +8,7 @@ workflow nested_scatter {
     scatter (y in ints2) {
       call xxx_add{ input: a = x, b = y }
 
-      Int i = ints1[x]
+      Int i = ints1[x-1]
       if (i < 3) {
         String s = "hello ${x} ${y}"
       }

--- a/compiler/src/test/resources/nested/nested_scatter.wdl
+++ b/compiler/src/test/resources/nested/nested_scatter.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+workflow nested_scatter {
+  Array[Int] ints1 = [1, 2, 3]
+  Array[Int] ints2 = [10, 11]
+
+  scatter (x in ints1) {
+    scatter (y in ints2) {
+      call xxx_add{ input: a = x, b = y }
+
+      Int i = ints1[x]
+      if (i < 3) {
+        String s = "hello ${x} ${y}"
+      }
+    }
+  }
+
+  output {
+    Array[Array[Int]] result = xxx_add.result
+    Array[String] strings = select_all(flatten(s))
+  }
+}
+
+task xxx_add {
+  input {
+    Int a
+    Int b
+  }
+  command {}
+  output {
+    Int result = a + b
+  }
+}

--- a/test/nested/nested_scatter.wdl
+++ b/test/nested/nested_scatter.wdl
@@ -8,7 +8,7 @@ workflow nested_scatter {
         scatter (y in ints2) {
             call xxx_add{ input: a = x, b = y }
 
-            Int i = ints1[x]
+            Int i = ints1[x-1]
             if (i < 3) {
                 String s = "hello ${x} ${y}"
             }

--- a/test/nested/nested_scatter.wdl
+++ b/test/nested/nested_scatter.wdl
@@ -1,15 +1,23 @@
 version 1.0
 
 workflow nested_scatter {
+    Array[Int] ints1 = [1, 2, 3]
+    Array[Int] ints2 = [10, 11]
 
-    scatter (x in [1, 2, 3]) {
-        scatter (y in [10, 11]) {
+    scatter (x in ints1) {
+        scatter (y in ints2) {
             call xxx_add{ input: a = x, b = y }
+
+            Int i = ints1[x]
+            if (i < 3) {
+                String s = "hello ${x} ${y}"
+            }
         }
     }
 
     output {
         Array[Array[Int]] result = xxx_add.result
+        Array[String] strings = select_all(flatten(s))
     }
 }
 

--- a/test/nested/nested_scatter_results.json
+++ b/test/nested/nested_scatter_results.json
@@ -1,5 +1,8 @@
 {
   "nested_scatter.result" : {
     "___": [[11, 12], [12, 13], [13, 14]]
-  }
+  },
+  "nested_scatter.strings": [
+    "hello 1 10", "hello 1 11", "hello 2 10", "hello 2 11"
+  ]
 }


### PR DESCRIPTION
The problem is illustrated by this WDL snippet:

```
    Array[Int] ints1 = [1, 2, 3]
    Array[Int] ints2 = [10, 11]

    scatter (x in ints1) {
        scatter (y in ints2) {
            call xxx_add{ input: a = x, b = y }

            Int i = ints1[x-1]
            if (i < 3) {
                String s = "hello ${x} ${y}"
            }
        }
    }
```

Currently, `ints1` and `ints2` are not added to the environment when translating the inner scatter, so the generated applet is missing inputs for those. This PR fixes the issue.