### PR TITLE
Apps 516 - error dereferencing struct as a call argument

### DIFF
--- a/compiler/src/test/resources/struct/struct_deref.wdl
+++ b/compiler/src/test/resources/struct/struct_deref.wdl
@@ -1,0 +1,34 @@
+version 1.0
+
+struct SampleStruct {
+  String sample_name
+}
+
+workflow struct_deref {
+  input {
+    SampleStruct sampleStruct
+  }
+
+  call test {
+    input:
+      sample_name = sampleStruct.sample_name
+  }
+
+  output {
+    String out = test.out
+  }
+}
+
+task test {
+  input {
+    String sample_name
+  }
+
+  command <<<
+    echo ~{sample_name}
+  >>>
+
+  output {
+    String out = read_string(stdout())
+  }
+}

--- a/compiler/src/test/scala/dx/translator/TranslatorTest.scala
+++ b/compiler/src/test/scala/dx/translator/TranslatorTest.scala
@@ -913,6 +913,14 @@ Main.compile(args.toVector) shouldBe a[SuccessfulCompileIR]
     retval shouldBe a[SuccessfulCompileIR]
   }
 
+  it should "handle access to struct member" in {
+    val path = pathFromBasename("struct", "struct_deref.wdl")
+    val args = path.toString :: cFlags
+    val retval =
+      Main.compile(args.toVector)
+    retval shouldBe a[SuccessfulCompileIR]
+  }
+
   it should "recognize that an argument with a default can be omitted at the call site" in {
     val path = pathFromBasename("compiler", "call_level2.wdl")
     val args = path.toString :: cFlags

--- a/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/WdlUtils.scala
@@ -702,10 +702,6 @@ object WdlUtils {
         }
       case TAT.ExprObject(value, _, _) => value.values.forall(TypeUtils.isPrimitiveValue)
 
-      // Access a field in a call or a struct
-      //   Int z = eliminateDuplicate.fields
-      case TAT.ExprGetName(_: TAT.ExprIdentifier, _, _, _) => true
-
       case _ => false
     }
   }

--- a/test/struct/struct_deref.wdl
+++ b/test/struct/struct_deref.wdl
@@ -1,0 +1,34 @@
+version 1.0
+
+struct SampleStruct {
+  String sample_name
+}
+
+workflow struct_deref {
+  input {
+    SampleStruct sampleStruct
+  }
+
+  call test {
+    input:
+      sample_name = sampleStruct.sample_name
+  }
+
+  output {
+    String out = test.out
+  }
+}
+
+task test {
+  input {
+    String sample_name
+  }
+
+  command <<<
+    echo ~{sample_name}
+  >>>
+
+  output {
+    String out = read_string(stdout())
+  }
+}

--- a/test/struct/struct_deref_input.json
+++ b/test/struct/struct_deref_input.json
@@ -1,0 +1,5 @@
+{
+  "struct_deref.sampleStruct": {
+    "sample_name": "George"
+  }
+}


### PR DESCRIPTION
In dxCompiler, a "trivial" expression is one that does not require evaluation to determine the value, i.e. it is a primitive value, a collection of primitives, or a reference to an input variable. We had also considered access to a field of a struct or a call return value as trivial, but this will not be the case for applets that are called directly as a stage in a workflow.

For example, in the following workflow, the applet for the `test` task takes a String input, but the call argument has to be evaluated at runtime, so we have to pass the struct (rather than the field value). Due to the mismatch between the call argument and the task input, a wrapper task is needed to evaluate the expression at runtime, which makes the expression non-trivial.

```
version 1.0

struct SampleStruct {
  String sample_name
}

workflow struct_deref {
  input {
    SampleStruct sampleStruct
  }

  call test {
    input:
      sample_name = sampleStruct.sample_name
  }

  output {
    String out = test.out
  }
}

task test {
  input {
    String sample_name
  }

  command <<<
    echo ~{sample_name}
  >>>

  output {
    String out = read_string(stdout())
  }
}
```