### PR TITLE
return error on empty return code file

### DIFF
--- a/compiler/src/main/resources/templates/applet_script.ssp
+++ b/compiler/src/main/resources/templates/applet_script.ssp
@@ -97,6 +97,10 @@
             echo "=== dxfuse filesystem log === "
             cat ${bashDollar}dxfuse_log
         fi
+        if [[ ${bashDollar}rc == '' ]]; then
+            echo "converting empty returnCode to 1"
+            rc=1
+        fi
         exit ${bashDollar}rc
     fi
     <% if (includeEpilog) { %>${include("epilog_script.ssp")}<% } %>


### PR DESCRIPTION
return error on empty return code file (e.g. when application runs out of disk space)