### PR TITLE
Fix integration test bugs

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -618,7 +618,9 @@ def run_test_subset(project, runnable, test_folder, debug_flag, delay_workspace_
             correct = True
             print("Checking results for workflow {} job {}".format(test_desc.name, i))
             for key, expected_val in shouldbe.items():
-                correct = validate_result(tname, exec_outputs, key, expected_val)
+                if not validate_result(tname, exec_outputs, key, expected_val):
+                    correct = False
+                    break
             anl_name = "{}.{}".format(tname, i)
             if correct:
                 print("Analysis {} passed".format(anl_name))

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -403,13 +403,18 @@ def validate_result(tname, exec_outputs, key, expected_val):
             result = exec_outputs[field_name1]
         elif field_name2 in exec_outputs:
             result = exec_outputs[field_name2]
+        elif expected_val is None:
+            # optional
+            return True
         else:
             cprint("field {} missing from executable results {}".format(field_name1, exec_outputs),
                    "red")
             return False
+        if isinstance(result, dict) and "___" in result:
+            result = result["___"]
         if isinstance(result, list) and isinstance(expected_val, list):
-            result.sort()
-            expected_val.sort()
+            result = list(sorted(filter(lambda x: x is not None, result)))
+            expected_val = list(sorted(filter(lambda x: x is not None, expected_val)))
         if isinstance(result, dict) and "$dnanexus_link" in result:
             # the result is a file - download it and extract the contents
             dlpath = os.path.join(tempfile.mkdtemp(), 'result.txt')


### PR DESCRIPTION
Fixing some issues in our integration test script:

* `verify_test` only failed if the last expected output to be checked is invalid
* Result failed validation if it was missing even if the expected value was `None` (i.e. the field is optional)
* Result failed validation if there was a mismatch between list values where the expected result contains `None` - DNAnexus does not preserve `null`s in outputs.