### PR TITLE
APPS-788 fix project-wide reuse

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 * Adds `-instanceTypeSelection` compiler option to allow disabling compile-type instance type selection
 * Adds `-defaultInstanceType` option
 * Adds support for new London region, `aws:eu-west-2-g`
+* Fixes `-projectWideReuse`
 
 ## 2.4.10 2021-08-16
 

--- a/compiler/src/main/scala/dx/compiler/Compiler.scala
+++ b/compiler/src/main/scala/dx/compiler/Compiler.scala
@@ -166,11 +166,11 @@ case class Compiler(extras: Option[Extras],
 
               |""".stripMargin
       )
-      // We need to sort the hash-tables. They are natually unsorted,
+      // We need to sort the hash-tables. They are naturally unsorted,
       // causing the same object to have different checksums.
       val digest =
         CodecUtils.md5Checksum(JsUtils.makeDeterministic(JsObject(desc)).prettyPrint)
-      // Add the checksum to the properies
+      // Add the checksum to the properties
       val existingDetails: Map[String, JsValue] =
         desc.get("details") match {
           case Some(JsObject(details)) => details

--- a/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
+++ b/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
@@ -75,13 +75,16 @@ case class DxExecutableDirectory(bundle: Bundle,
     val desc: Option[DxObjectDescribe] = Some(dxDesc)
   }
 
-  private def findExecutables(folder: Option[String]): Vector[(DxDataObject, DxObjectDescribe)] = {
+  private def findExecutables(
+      folder: Option[String] = None,
+      recurse: Boolean = false
+  ): Vector[(DxDataObject, DxObjectDescribe)] = {
     Vector("applet", "workflow")
       .flatMap { dxClass =>
         val constraints = DxFindDataObjectsConstraints(
             project = Some(project),
             folder = folder,
-            recurse = false,
+            recurse = recurse,
             objectClass = Some(dxClass),
             tags = Set(Constants.CompilerTag),
             names = allExecutableNames
@@ -140,40 +143,24 @@ case class DxExecutableDirectory(bundle: Bundle,
   private lazy val initialExecDir: Map[String, Vector[DxExecutableInfo]] = findExecutablesInFolder()
   private var execDir: Option[Map[String, Vector[DxExecutableInfo]]] = None
 
-  /**
-    * Scan the entire project for dx:workflows and dx:applets that we already created,
-    * and may be reused, instead of recompiling.
-    *
-    * Note: This could be expensive, and the maximal number of replies is (by default)
-    * 1000. Since the index is limited, we may miss matches when we search. The cost
-    * would be creating a dx:executable again, which is acceptable.
-    *
-    * findDataObjects can be an expensive call, both on the server and client sides.
-    * We limit it by filtering on the CHECKSUM property, which is attached only to
-    * generated applets and workflows.
-    *
-    * @return
-    */
-  private def findExecutablesInProject(): Map[String, Vector[DxExecutableInfo]] = {
-    findExecutables(None)
-      .flatMap {
-        case (obj, desc) =>
-          getChecksum(desc) match {
-            case Some(checksum) => Some(DxExecutableWithDesc(obj, desc, Some(checksum)))
-            case None           => None
-          }
-      }
-      .groupBy(_.checksum.get)
-  }
-
-  // A map from checksum to dx:executable, across the entire
-  // project.  It allows reusing dx:executables across the entire
-  // project, at the cost of a potentially expensive API call. It is
-  // not clear this is useful to the majority of users, so it is
-  // gated by the [projectWideReuse] flag.
+  // A map from checksum to dx:executable, across the entire project. It allows reusing dx:executables across the entire
+  // project, at the cost of a potentially expensive API call. It is not clear this is useful to the majority of users,
+  // so it is gated by the [projectWideReuse] flag.
   private lazy val projectWideExecDir: Map[String, Vector[DxExecutableInfo]] = {
     if (projectWideReuse) {
-      findExecutablesInProject()
+      // Scan the entire project for dx:workflows and dx:applets that we already created, and may be reused, instead of
+      // recompiling. This could be expensive. We limit it by filtering on the CHECKSUM property, which is attached only
+      // to generated applets and workflows. The maximal number of replies is (by default) 1000 so we may miss matches
+      // when we search. The cost would be creating a dx:executable again, which is acceptable.
+      logger.trace(s"Querying for executables in project ${project}")
+      val executables = findExecutables(recurse = true)
+        .flatMap {
+          case (obj, desc) =>
+            getChecksum(desc).map(checksum => DxExecutableWithDesc(obj, desc, Some(checksum)))
+        }
+        .groupBy(_.checksum.get)
+      logger.trace(s"Found ${executables.size} executables")
+      executables
     } else {
       Map.empty
     }

--- a/compiler/src/test/resources/bugs/apps-788.wdl
+++ b/compiler/src/test/resources/bugs/apps-788.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+task dyno_runtime {
+    input {
+        Int i
+    }
+    command <<<
+        echo "~{i}" > ~{i}
+        cat /etc/os-release >>~{i}
+    >>>
+    output {
+        File dyno_out="${i}"
+    }
+    runtime {
+        docker: if i > 2 then "ubuntu:focal" else "ubuntu:bionic"
+        memory: if i > 2 then "32GB" else "8GB"
+    }
+}

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -5,14 +5,13 @@ import java.nio.file.{Path, Paths}
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID.randomUUID
-
 import dx.Assumptions.{isLoggedIn, toolkitCallable}
 import dx.Tags.NativeTest
 import dx.api._
 import dx.core.Constants
 import dx.core.ir.Callable
 import dx.core.CliUtils.Termination
-import dx.util.{FileUtils, Logger, SysUtils}
+import dx.util.{FileUtils, JsUtils, Logger, SysUtils}
 import dxCompiler.Main
 import dxCompiler.Main.{SuccessfulCompileIR, SuccessfulCompileNativeNoTree}
 import org.scalatest.BeforeAndAfterAll
@@ -20,11 +19,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json._
 
-// This test module requires being logged in to the platform.
-// It compiles WDL scripts without the runtime library.
-// This tests the compiler Native mode, however, it creates
-// dnanexus applets and workflows that are not runnable.
-
+// This test module requires being logged in to the platform. It compiles WDL scripts without the runtime library.
+// This tests the compiler Native mode, however, it creates DNAnexus applets and workflows that are not runnable.
 class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   assume(isLoggedIn)
   assume(toolkitCallable)
@@ -38,7 +34,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   val testProject = "dxCompiler_playground"
 
-  private lazy val dxTestProject =
+  private val dxTestProject =
     try {
       dxApi.resolveProject(testProject)
     } catch {
@@ -49,25 +45,31 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         )
     }
 
-  private lazy val username = dxApi.whoami()
-  private lazy val unitTestsPath =
-    s"/unit_tests/${username}/CompilerTest/${LocalDateTime.now().toString}"
-  private lazy val cFlagsBase: List[String] = List(
+  private val username = dxApi.whoami()
+  private val unitTestsPath = {
+    val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
+    val test_time = dateFormatter.format(LocalDateTime.now)
+    s"/unit_tests/${username}/CompilerTest/${test_time}_${randomUUID().toString.substring(24)}"
+  }
+  private val reorgAppletFolder = s"${unitTestsPath}/reorg_applets"
+  private val unitTestsReusePath = s"${unitTestsPath}/reuse"
+  private var reorgAppletId: Option[String] = None
+
+  private val cFlagsBase: List[String] = List(
       "-project",
       dxTestProject.id,
       "-quiet",
       "-force"
   )
-  private lazy val cFlags: List[String] = cFlagsBase ++ List("-compileMode",
-                                                             "NativeWithoutRuntimeAsset",
-                                                             "-folder",
-                                                             unitTestsPath,
-                                                             "-locked")
-  private lazy val cFlagsReorgIR: List[String] = cFlagsBase ++
+  private val cFlags: List[String] = cFlagsBase ++ List("-compileMode",
+                                                        "NativeWithoutRuntimeAsset",
+                                                        "-folder",
+                                                        unitTestsPath,
+                                                        "-locked")
+  private val cFlagsReorgIR: List[String] = cFlagsBase ++
     List("-compileMode", "IR", "-folder", "/reorg_tests")
-  private lazy val cFlagsReorgCompile: List[String] = cFlagsBase ++
+  private val cFlagsReorgCompile: List[String] = cFlagsBase ++
     List("-compileMode", "NativeWithoutRuntimeAsset", "-folder", "/reorg_tests")
-  private lazy val unitTestsReusePath = s"${unitTestsPath}/reuse"
   private lazy val cFlagsReuse: List[String] = cFlagsBase ++
     List("-compileMode",
          "NativeWithoutRuntimeAsset",
@@ -75,53 +77,21 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
          unitTestsReusePath,
          "-projectWideReuse")
 
-  private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")
-  private val test_time = dateFormatter.format(LocalDateTime.now)
-
-  private val reorgAppletFolder =
-    s"${unitTestsPath}/reorg_applets_${test_time}_${randomUUID().toString.substring(24)}/"
-  private val reorgAppletPath = s"${reorgAppletFolder}/functional_reorg_test"
-
   override def beforeAll(): Unit = {
     // build the directory with the native applets
     dxTestProject.newFolder(reorgAppletFolder, parents = true)
     // building necessary applets before starting the tests
-    val nativeApplets = Vector("functional_reorg_test")
     val topDir = Paths.get(System.getProperty("user.dir"))
-    nativeApplets.foreach { app =>
-      try {
-        SysUtils.execCommand(
-            s"dx build $topDir/test/applets/$app --destination ${testProject}:${reorgAppletFolder}"
-        )
-      } catch {
-        case _: Throwable =>
-      }
-    }
+    val (_, appletIdJs, _) = SysUtils.execCommand(
+        s"dx build $topDir/test/applets/functional_reorg_test --destination ${testProject}:${reorgAppletFolder} --brief"
+    )
+    val JsString(appletId) = JsUtils.jsFromString(appletIdJs).asJsObject.fields("id")
+    reorgAppletId = Some(appletId)
   }
 
   override def afterAll(): Unit = {
     dxTestProject.removeFolder(unitTestsPath, recurse = true)
   }
-
-  private def getAppletId(path: String): String = {
-    val folder = Paths.get(path).getParent.toAbsolutePath.toString
-    val basename = Paths.get(path).getFileName.toString
-    val constraints = DxFindDataObjectsConstraints(
-        project = Some(dxTestProject),
-        folder = Some(folder),
-        recurse = false,
-        names = Set(basename)
-    )
-    val results = DxFindDataObjects(dxApi, Some(10)).query(
-        constraints,
-        withInputOutputSpec = false
-    )
-    results.size shouldBe 1
-    val desc = results.values.head
-    desc.id
-  }
-
-  private lazy val reorgAppletId = getAppletId(reorgAppletPath)
 
   private object WithExtras {
     def apply(extrasContent: String)(f: String => Termination): Termination = {
@@ -900,7 +870,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val extrasContent =
       s"""|{
           | "custom_reorg" : {
-          |    "app_id" : "${reorgAppletId}",
+          |    "app_id" : "${reorgAppletId.get}",
           |    "conf" : null
           |  }
           |}
@@ -924,7 +894,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val reorgStage = wfStages.last
 
     reorgStage.id shouldBe "stage-reorg"
-    reorgStage.executable shouldBe reorgAppletId
+    reorgStage.executable shouldBe reorgAppletId.get
 
     // There should be 3 inputs, the output from output stage and the custom reorg config file.
     val reorgInput: JsObject = reorgStage.input match {
@@ -949,7 +919,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val extrasContent =
       s"""|{
           | "custom_reorg" : {
-          |    "app_id" : "${reorgAppletId}",
+          |    "app_id" : "${reorgAppletId.get}",
           |    "conf" : "dx://$fileId"
           |  }
           |}
@@ -985,7 +955,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val extrasContent =
       s"""|{
           | "custom_reorg" : {
-          |    "app_id" : "${reorgAppletId}",
+          |    "app_id" : "${reorgAppletId.get}",
           |    "conf" : null
           |  }
           |}


### PR DESCRIPTION
Also improves `CompilerTest` to clean use a separate folder and clean it up at the end of the suite.