### PR TITLE
APPS-881 Fix print of dxfuse.log to joblog for failed jobs

### DIFF
--- a/compiler/src/main/resources/templates/applet_script.ssp
+++ b/compiler/src/main/resources/templates/applet_script.ssp
@@ -65,10 +65,9 @@ download_dxfuse() {
        echo "mounting dxfuse on ${dxPathConfig.getDxfuseMountDir().toString}"
        dxfuse_err_code=0
        dxfuse -readOnly "${dxPathConfig.getDxfuseMountDir().toString}" "${dxPathConfig.getDxfuseManifestFile().toString}" || dxfuse_err_code=${bashDollar}? && true
-
+       dxfuse_log=/root/.dxfuse/dxfuse.log
        if [[ ${bashDollar}dxfuse_err_code != 0 ]]; then
            echo "error starting dxfuse, rc=${bashDollar}dxfuse_err_code"
-           dxfuse_log=/root/.dxfuse/dxfuse.log
            # wait a second for the log to sync
            sleep 1
            if [[ -f ${bashDollar}dxfuse_log ]]; then


### PR DESCRIPTION
Always assign `dxfuse_log` variable. Previously only assigned a value if dxfuse failed to mount.