### PR TITLE
APPS-897 expand secondaryFiles

### DIFF
--- a/cwl_runner/dx_cwl_runner/compiler.py
+++ b/cwl_runner/dx_cwl_runner/compiler.py
@@ -414,10 +414,7 @@ class CwlCompiler(Compiler):
 
                     return value
 
-                inputs = dict(
-                    (key, update_input(value))
-                    for key, value in inputs.items()
-                )
+                inputs = dict((key, update_input(value)) for key, value in inputs.items())
 
         return inputs
 

--- a/cwl_runner/dx_cwl_runner/compiler.py
+++ b/cwl_runner/dx_cwl_runner/compiler.py
@@ -369,6 +369,25 @@ class CwlCompiler(Compiler):
         utils.check_tool("cwltool", ".+ ([\\d.]+)", "common-workflow-language/cwltool", self.dx.log)
         utils.check_tool("cwl-upgrader", None, "common-workflow-language/cwl-upgrader", self.dx.log)
 
+    def expand_inputs(self, process_file, job_file) -> dict:
+        input_deps = json.loads(
+            utils.run_cmd(f"cwltool --print-input-deps {process_file} {job_file}")
+        )
+
+        with open(job_file) as input_file:
+            inputs = json.load(input_file)
+            if input_deps:
+                # add any missing secondary files
+                def update_input(value):
+                    pass
+
+                inputs = dict(
+                    (key, update_input(value))
+                    for key, value in inputs.items()
+                )
+
+        return inputs
+
     def get_modified_input(self, i, basedir: str):
         if type(i) is list:
             return [self.get_modified_input(x, basedir) for x in i]
@@ -406,35 +425,6 @@ class CwlCompiler(Compiler):
 
         return i
 
-    # def expand_patterns(self, i: dict, value, schema_defs: dict):
-    #     def get_schema_type(t):
-    #         if isinstance(t, str):
-    #             schema_defs.get(t)
-    #         elif isinstance(t, dict) and t.get("type") == "array":
-    #             get_schema_type(t["items"])
-    #         elif isinstance(t, list):
-    #             schema_types = list(filter(None, [get_schema_type(x) for x in t]))
-    #             if len(schema_types) == 1:
-    #                 return schema_types[0]
-    #             elif len(schema_types) > 1:
-    #                 raise Exception("more than one schema type")
-    #
-    #     if (
-    #         isinstance(value, dict)
-    #         and value.get("class") in {"File", "Directory"}
-    #         and "secondaryFiles" not in value
-    #     ):
-    #         # we only care about file inputs that don't already have secondaryFiles defined
-    #         if "secondaryFiles" in i:
-    #             for sf in i["secondaryFiles"]:
-    #                 pass # TODO
-    #         else:
-    #             t = get_schema_type(i.get("type"))
-    #             if t:
-    #                 pass # TODO
-    #     else:
-    #         return value
-
     def create_compiler_input(
         self, process_file: str, job_file: str, basedir: str, tmpdir: str
     ) -> Tuple[str, str]:
@@ -442,17 +432,19 @@ class CwlCompiler(Compiler):
         #   if file does not exist, exception is thrown and no json is generated, even if some
         #   files were uploaded
 
+        # expand any secondaryFile patterns in the main process inputs with the inputs file
+        inputs = self.expand_inputs(process_file, job_file)
+
         # parse the inputs file
-        with open(job_file) as input_file:
-            inputs = json.load(input_file)
-            if "cwl:tool" in inputs:
-                tool = inputs.pop("cwl:tool")
-                if process_file is None:
-                    process_file = tool
-            modified_inputs = dict(
-                (k, self.get_modified_input(v, basedir))
-                for k, v in inputs.items()
-            )
+        if "cwl:tool" in inputs:
+            tool = inputs.pop("cwl:tool")
+            if process_file is None:
+                process_file = tool
+
+        modified_inputs = dict(
+            (k, self.get_modified_input(v, basedir))
+            for k, v in inputs.items()
+        )
 
         # try to pack the file
         packed_file = os.path.join(tmpdir, os.path.basename(process_file))
@@ -472,17 +464,6 @@ class CwlCompiler(Compiler):
         # read the CWL
         with open(packed_file, "rt") as inp:
             cwl = json.load(inp)
-
-        # expand any patterns in input secondaryFiles
-        # TODO: we may not need this if cwltool can implement an option to print this information
-        #  https://github.com/common-workflow-language/cwltool/issues/1556
-        # main_process = get_main_process(cwl)
-        # schema_defs = get_schema_defs(cwl)
-        # for i in main_process.get("inputs", []):
-        #     assert i["id"].startswith("#main/")
-        #     name = i["id"][6:]
-        #     if name in modified_inputs:
-        #         modified_inputs[name] = self.expand_patterns(i, modified_inputs[name], schema_defs)
 
         # write out the modified jobfile
         modified_jobfile = os.path.join(tmpdir, os.path.basename(job_file))

--- a/cwl_runner/pyproject.toml
+++ b/cwl_runner/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.poetry]
+c[tool.poetry]
 name = "dx_cwl_runner"
 version = "0.1.0"
 description = "DNAnexus implementation of cwl-runner interface"
@@ -9,7 +9,7 @@ authors = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-cwltool = "^3.1.20210922203925"
+cwltool = "^3.1.20211107152837"
 cwl-upgrader= "^1.2"
 
 [tool.poetry.dev-dependencies]

--- a/cwl_runner/pyproject.toml
+++ b/cwl_runner/pyproject.toml
@@ -1,4 +1,4 @@
-c[tool.poetry]
+[tool.poetry]
 name = "dx_cwl_runner"
 version = "0.1.0"
 description = "DNAnexus implementation of cwl-runner interface"

--- a/scripts/bundled_dependencies.json
+++ b/scripts/bundled_dependencies.json
@@ -8,7 +8,7 @@
         "name": "cwltool",
         "package_manager": "git",
         "url": "https://github.com/common-workflow-language/cwltool.git",
-        "tag": "3cf62d85e746790b811ab333814228beffec4d1c",
+        "tag": "0209b0b7ce66f03c8498b5a686f8d31690a2acb3",
         "build_commands": "make install"
       }
     ]


### PR DESCRIPTION
Thanks to https://github.com/common-workflow-language/cwltool/pull/1565, `cwltool --print-input-deps` now expands secondaryFile patterns in inputs. This PR uses that output to update the inputs prior to de-localizing.