### PR TITLE
allow runtime of native stub to override default instance type of native app(let)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Excludes apps from `bundledDepends`
 * Localizes files declared in WDL task private variables
+* Respects runtime definition in native task stub
 
 ## 2.8.0 2021-11-29
 

--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ val githubDxCompilerResolver = Resolver.githubPackages("dnanexus", "dxCompiler")
 lazy val dependencies =
   new {
     val dxCommonVersion = "0.9.0"
-    val dxApiVersion = "0.12.0"
+    val dxApiVersion = "0.12.1-SNAPSHOT"
     val dxFileAccessProtocolsVersion = "0.5.1"
     val dxYamlVersion = "0.1.0"
     val wdlToolsVersion = "0.17.4"

--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -8,7 +8,8 @@ import dx.api.{
   DxPath,
   DxProject,
   DxUtils,
-  DxWorkflow
+  DxWorkflow,
+  InstanceTypeRequest
 }
 import dx.core.Constants
 import dx.core.io.{DxWorkerPaths, StreamFiles}
@@ -173,11 +174,9 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
       executableDict: Map[String, ExecutableLink]
   ): (JsValue, Map[String, JsValue]) = {
     val instanceType: String = applet.instanceType match {
-      case static: StaticInstanceType =>
-        instanceTypeDb.apply(static.toInstanceTypeRequest).name
+      case static: StaticInstanceType                => instanceTypeDb.apply(static.req).name
       case DefaultInstanceType | DynamicInstanceType =>
-        // TODO: should we use the project default here rather than
-        //  picking one from the database?
+        // TODO: should we use the project default here rather than picking one from the database?
         defaultInstanceType.getOrElse(instanceTypeDb.defaultInstanceType.name)
     }
     // Generate the applet's job script
@@ -299,7 +298,9 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
     )
     // Add hard-coded instance type info to details
     val instanceTypeDetails: Map[String, JsValue] = applet.instanceType match {
-      case StaticInstanceType(Some(staticInstanceType), _, _, _, _, _, _, _, _, _) =>
+      case StaticInstanceType(
+          InstanceTypeRequest(Some(staticInstanceType), _, _, _, _, _, _, _, _, _, _)
+          ) =>
         Map(Constants.StaticInstanceType -> JsString(staticInstanceType))
       case _ => Map.empty
     }

--- a/compiler/src/test/scala/dx/translator/TranslatorTest.scala
+++ b/compiler/src/test/scala/dx/translator/TranslatorTest.scala
@@ -79,16 +79,16 @@ class TranslatorTest extends AnyFlatSpec with Matchers {
       applet.instanceType
     }
     compile("static") shouldBe StaticInstanceType(
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(ExecutionEnvironment("Ubuntu", "20.04", Vector("0")))
+        InstanceTypeRequest(None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            Some(ExecutionEnvironment("Ubuntu", "20.04", Vector("0"))))
     )
     compile("dynamic") shouldBe DynamicInstanceType
   }
@@ -1085,16 +1085,18 @@ Main.compile(args.toVector) shouldBe a[SuccessfulCompileIR]
         val (_, callable) = bundle.allCallables.head
         callable shouldBe a[Application]
         val task = callable.asInstanceOf[Application]
-        task.instanceType shouldBe StaticInstanceType(Some("mem3_ssd1_gpu_x8"),
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None,
-                                                      None)
+        task.instanceType shouldBe StaticInstanceType(
+            InstanceTypeRequest(Some("mem3_ssd1_gpu_x8"),
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None,
+                                None)
+        )
     }
   }
 

--- a/core/src/main/scala/dx/core/ir/RunSpec.scala
+++ b/core/src/main/scala/dx/core/ir/RunSpec.scala
@@ -1,13 +1,11 @@
 package dx.core.ir
 
-import dx.api.DiskType.DiskType
 import dx.api.{
   DiskType,
   DxApi,
   DxFile,
   DxInstanceType,
   DxProject,
-  ExecutionEnvironment,
   InstanceTypeDB,
   InstanceTypeRequest
 }
@@ -71,44 +69,15 @@ object RunSpec {
 
   case object DefaultInstanceType extends InstanceType
   case object DynamicInstanceType extends InstanceType
-  case class StaticInstanceType(
-      dxInstanceType: Option[String],
-      minMemoryMB: Option[Long],
-      maxMemoryMB: Option[Long],
-      minDiskGB: Option[Long],
-      maxDiskGB: Option[Long],
-      diskType: Option[DiskType],
-      minCpu: Option[Long],
-      maxCpu: Option[Long],
-      gpu: Option[Boolean],
-      os: Option[ExecutionEnvironment]
-  ) extends InstanceType {
-    def toInstanceTypeRequest: InstanceTypeRequest = {
-      InstanceTypeRequest(dxInstanceType,
-                          minMemoryMB,
-                          maxMemoryMB,
-                          minDiskGB,
-                          maxDiskGB,
-                          diskType,
-                          minCpu,
-                          maxCpu,
-                          gpu,
-                          os.orElse(Some(Constants.DefaultExecutionEnvironment)))
-    }
-  }
+  case class StaticInstanceType(req: InstanceTypeRequest) extends InstanceType
 
   object StaticInstanceType {
     def apply(req: InstanceTypeRequest): StaticInstanceType = {
-      StaticInstanceType(req.dxInstanceType,
-                         req.minMemoryMB,
-                         req.maxMemoryMB,
-                         req.minDiskGB,
-                         req.maxDiskGB,
-                         req.diskType,
-                         req.minCpu,
-                         req.maxCpu,
-                         req.gpu,
-                         req.os)
+      if (req.os.isEmpty) {
+        new StaticInstanceType(req.copy(os = Some(Constants.DefaultExecutionEnvironment)))
+      } else {
+        new StaticInstanceType(req)
+      }
     }
   }
 


### PR DESCRIPTION
If the WDL task stub for a native app(let) specifies runtime information, that information should be used to determine the instance type. Note that this only handles the cases where the native app(let) is called from a fragment or where the instance type is static.