### PR TITLE
Fix executable archiving

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Excludes apps from `bundledDepends`
 * Localizes files declared in WDL task private variables
+* Fixes archiving of executables - tags them as "archived" rather than renaming them
 
 ## 2.8.0 2021-11-29
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@
 * Excludes apps from `bundledDepends`
 * Localizes files declared in WDL task private variables
 * Respects runtime definition in native task stub
-* Fixes archiving of executables - tags them as "archived" rather than renaming them
+* Fixes archiving of executables - tags them as "dxCompilerArchived" rather than renaming them
 * Fixes error when parsing a field name with multiple `stage-*` prefixes (specifically with stage number >= 10)
 
 ## 2.8.0 2021-11-29

--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ val githubDxCompilerResolver = Resolver.githubPackages("dnanexus", "dxCompiler")
 lazy val dependencies =
   new {
     val dxCommonVersion = "0.9.0"
-    val dxApiVersion = "0.12.0"
+    val dxApiVersion = "0.12.1-SNAPSHOT"
     val dxFileAccessProtocolsVersion = "0.5.1"
     val dxYamlVersion = "0.1.0"
     val wdlToolsVersion = "0.17.4"

--- a/compiler/src/main/scala/dx/compiler/Compiler.scala
+++ b/compiler/src/main/scala/dx/compiler/Compiler.scala
@@ -241,8 +241,8 @@ case class Compiler(extras: Option[Extras],
                       .replaceAll("\n", " ")
                 )
                 val sorted = matching.sortBy(_.createdDate)
-                (Some(sorted.last), nonMatching ++ sorted.dropRight(1))
-              case (Vector(matching), nonMatching) => (Some(matching), nonMatching)
+                (Some(sorted.last.dataObj), nonMatching ++ sorted.dropRight(1))
+              case (Vector(matching), nonMatching) => (Some(matching.dataObj), nonMatching)
               case (_, nonMatching)                => (None, nonMatching)
             }
 
@@ -282,7 +282,7 @@ case class Compiler(extras: Option[Extras],
           }
 
           matching.foreach { m =>
-            logger.trace(s"Existing executable ${m.dataObj.id} with name ${name} has not changed")
+            logger.trace(s"Existing executable ${m.id} with name ${name} has not changed")
           }
 
           matching

--- a/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
+++ b/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
@@ -225,7 +225,9 @@ case class DxExecutableDirectory(bundle: Bundle,
   def archive(execInfo: DxExecutableInfo): Unit = {
     logger.trace(s"Archiving ${execInfo.name} ${execInfo.dataObj.id}")
     // tag the object
-    dxApi.addTags(execInfo.dataObj, Vector(DxExecutableDirectory.ArchivedTag))
+    dxApi.addTags(execInfo.dataObj,
+                  Vector(DxExecutableDirectory.ArchivedTag),
+                  project = Some(project))
     // move the object to the new location
     val archiveName = execInfo.createdDate match {
       case Some(dt) => s"${execInfo.name} ${dt.format(dateFormatter)}"

--- a/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
+++ b/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
@@ -4,19 +4,19 @@ import java.time.{LocalDateTime, ZoneId}
 import java.time.format.DateTimeFormatter
 import dx.api.{
   DxApi,
-  DxApp,
   DxApplet,
+  DxAppletDescribe,
   DxDataObject,
   DxFindDataObjects,
   DxFindDataObjectsConstraints,
   DxObjectDescribe,
   DxProject,
   DxWorkflow,
+  DxWorkflowDescribe,
   Field
 }
 import dx.core.Constants
 import dx.core.ir.Bundle
-import spray.json.JsString
 import dx.util.{JsUtils, Logger}
 
 trait DxExecutableInfo {
@@ -25,27 +25,21 @@ trait DxExecutableInfo {
   val checksum: Option[String]
   val createdDate: Option[LocalDateTime]
   def name: String
+}
 
-  lazy val dxClass: String = {
-    dataObj match {
-      case _: DxApp      => "App"
-      case _: DxApplet   => "Applet"
-      case _: DxWorkflow => "Workflow"
-      case _             => dataObj.getClass.getSimpleName
-    }
-  }
+object DxExecutableDirectory {
+  val ArchivedTag = "archived"
 }
 
 /**
-  * Takes a snapshot of the platform target path before the build starts.
-  * Makes an efficient directory of all the applets that exist there. Update
-  * the directory when an applet is compiled.
-  *
+  * Takes a snapshot of the platform target path before the build starts. Provides methods for
+  * querying and updating the directory.
   * @param bundle an IR bundle
   * @param project the project to search
   * @param folder the folder to search
   * @param projectWideReuse whether to allow project-wide reuse
   * @param dxApi the Dx API
+  * @param logger the logger
   */
 case class DxExecutableDirectory(bundle: Bundle,
                                  project: DxProject,
@@ -55,9 +49,8 @@ case class DxExecutableDirectory(bundle: Bundle,
                                  logger: Logger = Logger.get) {
 
   // a list of all dx:workflow and dx:applet names used in this WDL workflow
-  private lazy val allExecutableNames: Set[String] = bundle.allCallables.keySet
-  // API interface
-  private lazy val dxFind = DxFindDataObjects(dxApi)
+  private val allExecutableNames: Set[String] = bundle.allCallables.keySet
+  private val dxFind = DxFindDataObjects(dxApi)
 
   /**
     * Information about a Dx data object.
@@ -79,29 +72,32 @@ case class DxExecutableDirectory(bundle: Bundle,
       folder: Option[String] = None,
       recurse: Boolean = false
   ): Vector[(DxDataObject, DxObjectDescribe)] = {
-    Vector("applet", "workflow")
-      .flatMap { dxClass =>
-        val constraints = DxFindDataObjectsConstraints(
-            project = Some(project),
-            folder = folder,
-            recurse = recurse,
-            objectClass = Some(dxClass),
-            tags = Set(Constants.CompilerTag),
-            names = allExecutableNames
-        )
-        val t0 = System.nanoTime()
-        val dxObjectsInFolder: Map[DxDataObject, DxObjectDescribe] = dxFind.query(
-            constraints,
-            withInputOutputSpec = false,
-            extraFields = Set(Field.Details)
-        )
-        val t1 = System.nanoTime()
-        val diffMSec = (t1 - t0) / (1000 * 1000)
-        logger.trace(
-            s"Found ${dxObjectsInFolder.size} ${dxClass} in ${project.id} folder=${folder} (${diffMSec} millisec)"
-        )
-        dxObjectsInFolder.toVector
+    val constraints = DxFindDataObjectsConstraints(
+        project = Some(project),
+        folder = folder,
+        recurse = recurse,
+        tags = Set(Constants.CompilerTag),
+        names = allExecutableNames
+    )
+    val dxObjectsInFolder = dxFind
+      .query(
+          constraints,
+          withInputOutputSpec = false,
+          defaultFields = true,
+          extraFields = Set(Field.Tags, Field.Properties, Field.Details)
+      )
+      .filter {
+        case (_: DxApplet, desc: DxAppletDescribe)
+            if !desc.tags.exists(_.contains(DxExecutableDirectory.ArchivedTag)) =>
+          true
+        case (_: DxWorkflow, desc: DxWorkflowDescribe)
+            if !desc.tags.exists(_.contains(DxExecutableDirectory.ArchivedTag)) =>
+          true
+        case _ => false
       }
+      .toVector
+    logger.trace(s"Found ${dxObjectsInFolder.size} executables in ${project.id}:${folder}")
+    dxObjectsInFolder
   }
 
   private def getChecksum(desc: DxObjectDescribe): Option[String] = {
@@ -111,19 +107,16 @@ case class DxExecutableDirectory(bundle: Bundle,
       .orElse(desc.properties.flatMap(_.get(Constants.ChecksumPropertyDeprecated)))
   }
 
-  /**
-    * Instead of looking up applets/workflows one by one, perform a bulk lookup, and
-    * find all the objects in the target directory. Setup an easy to
-    * use map with information on each name.
-    *
-    * findDataObjects can be an expensive call, both on the server and client sides.
-    * We limit it by filtering on the CHECKSUM property, which is attached only to
-    * generated applets and workflows. This runs the risk of missing cases where an
-    * applet name is already in use by a regular dnanexus applet/workflow.
-    *
-    * @return
-    */
-  private def findExecutablesInFolder(): Map[String, Vector[DxExecutableInfo]] = {
+  /*
+   * Instead of looking up applets/workflows one by one, perform a bulk lookup, and find all the
+   * objects in the target directory. Setup an easy to use map with information on each name.
+   *
+   * findDataObjects can be an expensive call, both on the server and client sides. We limit it by
+   * filtering on the CHECKSUM property, which is attached only to generated applets and workflows.
+   * This runs the risk of missing cases where an applet name is already in use by a regular
+   * dnanexus applet/workflow.
+   */
+  private lazy val initialExecDir: Map[String, Vector[DxExecutableInfo]] = {
     findExecutables(Some(folder))
       .map {
         case (dxObj, desc) =>
@@ -137,10 +130,6 @@ case class DxExecutableDirectory(bundle: Bundle,
       }
       .groupBy(_.name)
   }
-
-  // A map from an applet/workflow that is part of the namespace to its dx:object
-  // on the target path (project/folder)
-  private lazy val initialExecDir: Map[String, Vector[DxExecutableInfo]] = findExecutablesInFolder()
   private var execDir: Option[Map[String, Vector[DxExecutableInfo]]] = None
 
   // A map from checksum to dx:executable, across the entire project. It allows reusing executables
@@ -177,9 +166,9 @@ case class DxExecutableDirectory(bundle: Bundle,
   }
 
   /**
-    * Searches for an executable with a specific checksum anywhere in the project.
-    * In case of checksum collision (i.e. multiple results for the same checksum),
-    * returns only the executable that starts with the name we are looking for.
+    * Searches for an executable with a specific checksum anywhere in the project. In case of
+    * checksum collision (i.e. multiple results for the same checksum), returns only the executable
+    * that starts with the name we are looking for.
     * @param name the executable name to look up
     * @param digest the executable's checksum
     * @return
@@ -208,17 +197,17 @@ case class DxExecutableDirectory(bundle: Bundle,
   def insert(name: String, dxExec: DxDataObject, digest: String): Unit = {
     val info = DxExecutableInserted(name, dxExec, Some(digest))
     execDir = execDir.getOrElse(initialExecDir) match {
-      case d if d.contains(name) =>
-        Some(d + (name -> (d(name) :+ info)))
-      case d =>
-        Some(d + (name -> Vector(info)))
+      case d if d.contains(name) => Some(d + (name -> (d(name) :+ info)))
+      case d                     => Some(d + (name -> Vector(info)))
     }
   }
 
   private lazy val dateFormatter = DateTimeFormatter.ofPattern("EE MMM dd kk:mm:ss yyyy")
   private var folders: Set[String] = Set.empty
 
-  // create a folder, if it does not already exist.
+  /**
+    * Creates a folder if it does not already exist.
+    */
   private def ensureFolder(fullPath: String): Unit = {
     if (!folders.contains(fullPath)) {
       project.newFolder(fullPath, parents = true)
@@ -227,43 +216,24 @@ case class DxExecutableDirectory(bundle: Bundle,
   }
 
   /**
-    * Moves an object into an archive directory. If the object
-    * is an applet, for example /A/B/C/GLnexus, move it to
-    *     /A/B/C/Applet_archive/GLnexus (Day Mon DD hh:mm:ss year)
-    * If the object is a workflow, move it to
-    *     /A/B/C/Workflow_archive/GLnexus (Day Mon DD hh:mm:ss year)
-    *
-    * Examples:
-    *   GLnexus (Fri Aug 19 18:01:02 2016)
-    *   GLnexus (Mon Mar  7 15:18:14 2016)
-    *
-    * Note: 'dx build' does not support workflow archiving at the moment.
-    *
+    * Moves an executable into an archive directory. For example if the applet is /A/B/C/GLnexus,
+    * moves it to /A/B/C/.archive/GLnexus {date}/GLnexus. The archived executable is tagged with
+    * "archived" so that it can be filtered out when searching for existing applets.
     * TODO: need to update the execInfo in the directory
-    *
     * @param execInfo the object to archive
     */
   def archive(execInfo: DxExecutableInfo): Unit = {
     logger.trace(s"Archiving ${execInfo.name} ${execInfo.dataObj.id}")
-    val dxClass: String = execInfo.dxClass
+    // tag the object
+    dxApi.addTags(execInfo.dataObj, Vector(DxExecutableDirectory.ArchivedTag))
     // move the object to the new location
-    val destFolder = s"${folder}/${dxClass}_archive"
+    val archiveName = execInfo.createdDate match {
+      case Some(dt) => s"${execInfo.name} ${dt.format(dateFormatter)}"
+      case None     => execInfo.name
+    }
+    val destFolder = s"${folder}/.archive/${archiveName}/"
     ensureFolder(destFolder)
     project.moveObjects(Vector(execInfo.dataObj), destFolder)
-    // add the date to the object name
-    val name = execInfo.createdDate match {
-      case None     => execInfo.name
-      case Some(dt) => s"${execInfo.name} ${dt.format(dateFormatter)}"
-    }
-    val request = Map("project" -> JsString(project.id), "name" -> JsString(name))
-    logger.ignore(dxClass match {
-      case "Workflow" =>
-        dxApi.workflowRename(execInfo.dataObj.id, request)
-      case "Applet" =>
-        dxApi.appletRename(execInfo.dataObj.id, request)
-      case other =>
-        throw new Exception(s"Cannot archive object ${execInfo} with class ${other}")
-    })
   }
 
   /**
@@ -281,7 +251,7 @@ case class DxExecutableDirectory(bundle: Bundle,
     */
   def remove(execInfos: Vector[DxExecutableInfo]): Unit = {
     val objs = execInfos.map(_.dataObj)
-    logger.trace(s"Removing old executables ${objs.map(_.id)}")
+    logger.trace(s"Removing executables ${objs.map(_.id)}")
     project.removeObjects(objs, force = true)
   }
 }

--- a/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
+++ b/compiler/src/main/scala/dx/compiler/DxExecutableDirectory.scala
@@ -28,7 +28,7 @@ trait DxExecutableInfo {
 }
 
 object DxExecutableDirectory {
-  val ArchivedTag = "archived"
+  val ArchivedTag = "dxCompilerArchived"
 }
 
 /**
@@ -218,7 +218,7 @@ case class DxExecutableDirectory(bundle: Bundle,
   /**
     * Moves an executable into an archive directory. For example if the applet is /A/B/C/GLnexus,
     * moves it to /A/B/C/.archive/GLnexus {date}/GLnexus. The archived executable is tagged with
-    * "archived" so that it can be filtered out when searching for existing applets.
+    * "dxCompilerArchived" so that it can be filtered out when searching for existing applets.
     * TODO: need to update the execInfo in the directory
     * @param execInfo the object to archive
     */

--- a/compiler/src/test/resources/compiler/add_changed.wdl
+++ b/compiler/src/test/resources/compiler/add_changed.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+task add {
+  input {
+    Int a
+    Int c
+  }
+  command {
+    echo $((${a} + ${c}))
+  }
+  meta {
+    summary: "Adds two int together"
+  }
+
+  output {
+    Int result = read_int(stdout())
+  }
+}

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -797,9 +797,10 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
     desc.runSpec match {
       case Some(rs) => {
-        val bundledDepends = rs.asJsObject.fields
-          .get("bundledDepends")
-          .getOrElse(throw new Exception(s"Expected ${appletId} to have bundledDepends"))
+        val bundledDepends = rs.asJsObject.fields.getOrElse(
+            "bundledDepends",
+            throw new Exception(s"Expected ${appletId} to have bundledDepends")
+        )
         bundledDepends match {
           case JsArray(items) => {
             val searchItem = items.find(v => v.asJsObject.toString.contains(bundledName))
@@ -1269,6 +1270,37 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     val args = path.toString :: cFlags
     val retval = Main.compile(args.toVector)
     retval shouldBe a[SuccessfulCompileNativeNoTree]
+  }
+
+  it should "archive an identical task" in {
+    val folder = s"${unitTestsPath}/testArchive"
+    val flags = cFlagsBase ++ List("-compileMode",
+                                   "NativeWithoutRuntimeAsset",
+                                   "-folder",
+                                   folder,
+                                   "-locked")
+    val path1 = pathFromBasename("compiler", "add.wdl")
+    val args1 = path1.toString :: flags
+    // compile once
+    val appletId1 = Main.compile(args1.toVector) match {
+      case SuccessfulCompileNativeNoTree(_, Vector(appletId)) => appletId
+      case other =>
+        throw new Exception(s"expected single applet not ${other}")
+    }
+    // compile slightly changed version with archive flag
+    val path2 = pathFromBasename("compiler", "add_changed.wdl")
+    val args2 = path2.toString :: "-archive" :: flags
+    val appletId2 = Main.compile(args2.toVector) match {
+      case SuccessfulCompileNativeNoTree(_, Vector(appletId)) => appletId
+      case other =>
+        throw new Exception(s"expected single applet not ${other}")
+    }
+    appletId1 should not be appletId2
+    // check that first applet has moved to a .archive folder and tagged with "archived"
+    val desc = dxApi.applet(appletId1).describe(Set(Field.Tags))
+    desc.folder should startWith(s"${folder}/.archive")
+    desc.tags should not be empty
+    desc.tags.get should contain(DxExecutableDirectory.ArchivedTag)
   }
 
   it should "reuse identical tasks" in {


### PR DESCRIPTION
Currently, when the compiler is run with the `-a` flag, any existing executables with name collisions are archived by renaming them. This breaks the archived workflow because in other parts of the code we rely on the executable name being the same as the task name. This PR fixes the archival process to instead move the executable to a `.archive/<name> <date>` folder and adds the "archived" tag. We then exclude executables with the "archived" tag when searching.