### PR TITLE
fix regex for parsing stage IDs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Excludes apps from `bundledDepends`
 * Localizes files declared in WDL task private variables
 * Respects runtime definition in native task stub
+* Fixes error when parsing a field name with multiple `stage-*` prefixes (specifically with stage number >= 10)
 
 ## 2.8.0 2021-11-29
 

--- a/core/src/main/scala/dx/core/ir/DxName.scala
+++ b/core/src/main/scala/dx/core/ir/DxName.scala
@@ -288,7 +288,7 @@ trait DxNameFactory {
 object DxNameFactory {
   // standard suffixes to parse
   val suffixes = Set(Constants.ComplexValueKey, Constants.FlatFilesSuffix)
-  private val stageRegex = "^(?:((?:stage-[^.]\\.)*stage-[^.]+)\\.)?(.+)$".r
+  private val stageRegex = "^(?:((?:stage-[^.]+\\.)*stage-[^.]+)\\.)?(.+)$".r
 
   // the default Regex.split method does not return parts with empty strings -
   // we need those for validation

--- a/core/src/test/scala/dx/core/ir/DxNameTest.scala
+++ b/core/src/test/scala/dx/core/ir/DxNameTest.scala
@@ -92,6 +92,13 @@ class DxNameTest extends AnyFlatSpec with Matchers {
     dxName3.withSuffix("___dxfiles") shouldBe dxName
   }
 
+  it should "decode a WDL name with multiple stages" in {
+    val dxName = WdlDxName.fromEncodedName("stage-14.stage-22.a___dxfiles")
+    dxName.stage shouldBe Some("stage-14.stage-22")
+    dxName.getDecodedParts shouldBe Vector("a")
+    dxName.suffix shouldBe Some("___dxfiles")
+  }
+
   it should "not encode WDL names with illegal characters" in {
     assertThrows[Throwable] {
       WdlDxName.fromDecodedName("  ")


### PR DESCRIPTION
Fix for regex that misses stage IDs >= 10