### PR TITLE
APPS-1014 fail on error code even without `runtime`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## in develop
+
+* Fixes issue where task without `runtime` section succeeds even when command block results in a failure code
+
 ## 2.8.1 2021-12-13
 
 * Excludes apps from `bundledDepends`

--- a/core/src/main/scala/dx/core/languages/wdl/Runtime.scala
+++ b/core/src/main/scala/dx/core/languages/wdl/Runtime.scala
@@ -142,6 +142,6 @@ case class Runtime(wdlVersion: WdlVersion,
   }
 
   def returnCodes: Option[Set[Int]] = {
-    runtimeAttrs.runtime.flatMap(_.returnCodes)
+    runtimeAttrs.runtime.map(_.returnCodes).getOrElse(Some(WdlRuntime.ReturnCodesDefault))
   }
 }

--- a/executorWdl/src/test/resources/task_runner/read_tsv_x.wdl
+++ b/executorWdl/src/test/resources/task_runner/read_tsv_x.wdl
@@ -8,7 +8,7 @@ task read_tsv_x {
     for l in ll:
       tsv_list.append('\t'.join(l))
     tsv_string = '\n'.join(tsv_list)
-    print tsv_string
+    print(tsv_string)
     CODE
     >>>
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -57,6 +57,7 @@ expected_failure = {
     "cond-wf-006_nojs.1",
     "cond-wf-012_nojs",
     "fail-unconnected",
+    "apps_1014"
 }
 
 test_compilation_failing = {"import_passwd"}
@@ -118,6 +119,7 @@ wdl_v1_list = [
     "nested_optional",
     "struct_deref",  # APPS-615
     "apps_936",
+    "apps_1014",
 
     # manifests
     "simple_manifest",

--- a/test/bugs/apps_1014.wdl
+++ b/test/bugs/apps_1014.wdl
@@ -1,0 +1,7 @@
+version 1.0
+
+task apps_1014 {
+  command <<<
+  exit 1
+  >>>
+}


### PR DESCRIPTION
fix issue where task without `runtime` section succeeds even when command block results in a failure code