### PR TITLE
APPS-897 Add missing release note for cwltool to cwlpack

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 * Command file is now echoed to stderr rather than stdout
 * Fixes a bug where directory support was broken for WDL; directories in WDL are represented as strings
+* Switches from using cwltool to cwlpack
 
 ## 2.8.3 2022-01-07
 


### PR DESCRIPTION
APPS-897 PR was already merged; this adds missing release note for that change