### PR TITLE
APPS-1115 add prefix to invalid cwl

### DIFF
--- a/core/src/main/scala/dx/core/ir/DxName.scala
+++ b/core/src/main/scala/dx/core/ir/DxName.scala
@@ -345,7 +345,8 @@ object DxNameFactory {
       case stageRegex(stage, rest) => (Option(stage), rest)
     }
     val (prefix, suffix) = splitSuffix(rest)
-    (splitParts(prefix), stage, suffix)
+    val parts = splitParts(prefix).dropWhile(_.isEmpty())
+    (parts, stage, suffix)
   }
 }
 

--- a/core/src/test/scala/dx/core/ir/DxNameTest.scala
+++ b/core/src/test/scala/dx/core/ir/DxNameTest.scala
@@ -271,13 +271,21 @@ class DxNameTest extends AnyFlatSpec with Matchers {
     dxName.encoded shouldBe "___47___47__45__a__45__b___c__46__d___dxfiles"
     dxName.suffix shouldBe Some("___dxfiles")
 
-    val dxName2 = CwlDxName.fromDecodedName("c.d___dxfiles")
-    dxName.endsWith(dxName2) shouldBe true
-    dxName2.pushDecodedNamespaces(Vector("47", "47-a-b")) shouldBe dxName
     dxName.popDecodedIdentifier() shouldBe (CwlDxName.fromEncodedName(
         "___47___47__45__a__45__b"
     ), "c.d")
-    dxName2.encoded shouldBe "___47__45__a__45__b___c__46__d"
+    val dxName1alter = dxName.popDecodedIdentifier()._1
+    dxName1alter.popDecodedIdentifier() shouldBe (CwlDxName.fromEncodedName(
+        "___47"
+    ), "47-a-b")
+
+    val dxName2 = CwlDxName.fromDecodedName("c.d___dxfiles")
+    dxName.endsWith(dxName2) shouldBe true
+    dxName2.pushDecodedNamespaces(Vector("47", "47-a-b")) shouldBe dxName
+
+    val dxName2alter = dxName2.pushDecodedNamespaces(Vector("47-a-b"))
+    dxName2alter.encoded shouldBe "___47__45__a__45__b___c__46__d___dxfiles"
+    dxName2alter.pushDecodedNamespaces(Vector("47")) shouldBe dxName
 
     val dxName3 = dxName.dropSuffix()
     dxName3.suffix shouldBe None

--- a/core/src/test/scala/dx/core/ir/DxNameTest.scala
+++ b/core/src/test/scala/dx/core/ir/DxNameTest.scala
@@ -261,4 +261,29 @@ class DxNameTest extends AnyFlatSpec with Matchers {
     val m = Map(dxName1 -> "x")
     m(dxName2) shouldBe "x"
   }
+
+  it should "add a leading slash before CWL names started with a number" in {
+    val dxName = CwlDxName.fromDecodedName("47/47-a-b/c.d___dxfiles")
+    dxName.numParts shouldBe 3
+    dxName.getDecodedParts shouldBe Vector("47", "47-a-b", "c.d")
+    dxName.getEncodedParts shouldBe Vector("47", "47__45__a__45__b", "c__46__d")
+    dxName.decoded shouldBe "47/47-a-b/c.d___dxfiles"
+    dxName.encoded shouldBe "___47___47__45__a__45__b___c__46__d___dxfiles"
+    dxName.suffix shouldBe Some("___dxfiles")
+
+    val dxName2 = CwlDxName.fromDecodedName("c.d___dxfiles")
+    dxName.endsWith(dxName2) shouldBe true
+    dxName2.pushDecodedNamespaces(Vector("47", "47-a-b")) shouldBe dxName
+    dxName.popDecodedIdentifier() shouldBe (CwlDxName.fromEncodedName(
+        "___47___47__45__a__45__b"
+    ), "c.d")
+    dxName2.encoded shouldBe "___47__45__a__45__b___c__46__d"
+
+    val dxName3 = dxName.dropSuffix()
+    dxName3.suffix shouldBe None
+    dxName3.encoded shouldBe "___47___47__45__a__45__b___c__46__d"
+    dxName3.decoded shouldBe "47/47-a-b/c.d"
+
+    dxName3.withSuffix("___dxfiles") shouldBe dxName
+  }
 }

--- a/executorCwl/src/main/scala/dx/executor/cwl/CwlTaskExecutor.scala
+++ b/executorCwl/src/main/scala/dx/executor/cwl/CwlTaskExecutor.scala
@@ -404,7 +404,7 @@ case class CwlTaskExecutor(tool: Process,
     }
     JsUtils.jsToFile(inputJson, inputPath)
     // if a target is specified (a specific workflow step), add the --single-process option
-    val targetOpt = rawStep.map(t => s"--single-process ${t}").getOrElse("")
+    val targetOpt = rawStep.map(t => s"--single-process '${t}'").getOrElse("")
     // if a dx:// URI is specified for the Docker container, download it and create an overrides
     // file to override the value in the CWL file
     val requirementOverrides =


### PR DESCRIPTION
This PR includes changes that add a prefix to CWL ids if they start with characters disallowed by the DNAnexus platform.
Specs and notes can be found here:
https://docs.google.com/document/d/1m0YI4xO9wPHSfLIWGafKPSQDA_Uz5iY5tH6qxamP428/edit?usp=sharing