### PR TITLE
APPS-1137 Update compiler options help to include CWL

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ $ dx run bam_chrom_counter -istage-common.bam=project-BQbJpBj0bvygyQxgQ1800Jkk:f
   * The [alternative workflow output syntax](https://github.com/openwdl/wdl/blob/main/versions/draft-2/SPEC.md#outputs) that has been deprecated since WDL draft2 is not supported
   * The `call ... after` syntax introduced in WDL 1.1 is not yet supported
 * CWL only
+  * Calling native DNAnexus apps/applets in CWL workflow using `dxni` is not supported.
   * `SoftwareRequirement` and `InplaceUpdateRequirement` are not yet supported
   * Publishing a dxCompiler-generated workflow as a global workflow is not supported
 

--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -903,7 +903,7 @@ object Main {
         |    -project <string>        Platform project (defaults to currently selected project).
         |    -language <string> [ver] Which language to use? May be WDL or CWL. You can optionally 
         |                             specify a version. Currently: i. WDL: draft-2, 1.0, and 1.1, and
-        |                             ii. CWL: 1.2 are fully supported and WDL development is partially
+        |                             ii. CWL: 1.2 are supported and WDL development is partially
         |                             supported. The default is to auto-detect the language from the
         |                             source file.
         |    -quiet                   Do not print warnings or informational outputs.

--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -833,7 +833,14 @@ object Main {
         |    Compile a WDL or CWL file to a DNAnexus workflow or applet.
         |    options
         |      -archive               Archive older versions of applets.
-        |      -compileMode <string>  Compilation mode - a debugging flag for internal use.
+        |      -compileMode [IR, NativeWithoutRuntimeAsset, All]
+        |                             Compilation mode. If not specified, the compilation mode 
+        |                             is "All" and the compiler will translate and compile the workflow 
+        |                             file into applications that are bundled with runtime asset.
+        |                             Use "IR" if you only want to translate the file and generate
+        |                             the DNAnexus JSON input file from a standard-formatted one
+        |                             without compilation, or use "NativeWithoutRuntimeAsset" if you 
+        |                             don't want to package the runtime asset with generated applications.
         |      -defaults <string>     JSON file with standard-formatted default values.
         |      -defaultInstanceType <string>
         |                             The default instance type to use for "helper" applets

--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -331,7 +331,7 @@ object Main {
       .map(Paths.get(_))
       .getOrElse(
           throw OptionParseException(
-              "Missing required positional argument <WDL file>"
+              "Missing required positional argument <WDL or CWL file>"
           )
       )
     val options: Options =
@@ -735,7 +735,7 @@ object Main {
   def describe(args: Vector[String]): Termination = {
     val workflowId = args.headOption.getOrElse(
         throw OptionParseException(
-            "Missing required positional argument <WDL file>"
+            "Missing required positional argument <WDL or CWL file>"
         )
     )
     val options =
@@ -829,8 +829,8 @@ object Main {
         |    options
         |      -pretty                Print exec tree in "pretty" text format instead of JSON.
         |
-        |  compile <WDL file>
-        |    Compile a WDL file to a DNAnexus workflow or applet.
+        |  compile <WDL or CWL file>
+        |    Compile a WDL or CWL file to a DNAnexus workflow or applet.
         |    options
         |      -archive               Archive older versions of applets.
         |      -compileMode <string>  Compilation mode - a debugging flag for internal use.
@@ -854,7 +854,7 @@ object Main {
         |                             (the default "static" option), or to defer instance type
         |                             selection in such cases to runtime (the "dynamic" option).
         |                             Using static instance type selection can save time, but it
-        |                             requires the same set of instances to be accessible during WDL
+        |                             requires the same set of instances to be accessible during WDL/CWL
         |                             compilation and during the runtime of the generated applets and
         |                             workflows. Use the "dynamic" option if you plan on creating global
         |                             DNAnexus workflows or cloning the generated workflows between
@@ -862,7 +862,7 @@ object Main {
         |      -locked                Create a locked workflow. When running a locked workflow,
         |                             input values may only be specified for the top-level workflow.
         |      -leaveWorkflowsOpen    Leave created workflows open (otherwise they are closed).
-        |      -p | -imports <string> Directory to search for imported WDL files. May be specified
+        |      -p | -imports <string> Directory to search for imported WDL or CWL files. May be specified
         |                             multiple times.
         |      -projectWideReuse      Look for existing applets/workflows in the entire project
         |                             before generating new ones. The default search scope is the
@@ -902,8 +902,8 @@ object Main {
         |    -folder <string>         Platform folder (defaults to '/').
         |    -project <string>        Platform project (defaults to currently selected project).
         |    -language <string> [ver] Which language to use? May be WDL or CWL. You can optionally 
-        |                             specify a version. Currently, WDL draft-2, 1.0, and 1.1 are
-        |                             fully supported and WDL development and CWL 1.2 are partially
+        |                             specify a version. Currently: i. WDL: draft-2, 1.0, and 1.1, and
+        |                             ii. CWL: 1.2 are fully supported and WDL development is partially
         |                             supported. The default is to auto-detect the language from the
         |                             source file.
         |    -quiet                   Do not print warnings or informational outputs.

--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -890,7 +890,7 @@ object Main {
         |                             outputs. Implies -locked.
         |      -waitOnUpload          Whether to wait for each file upload to complete.
         |
-        |  dxni
+        |  dxni (WDL only)
         |    DNAnexus Native call Interface. Creates stubs for calling DNAnexus executables 
         |    (apps/applets/workflows), and stores them as WDL tasks in a local file. Enables 
         |    calling existing platform executables without modification.


### PR DESCRIPTION
Note: `wdlOptions` variable name is not updated since it would require code update (at this point large integration tests are already running so I'd only like to update docstrings).