### PR TITLE
APPS-1377 dxcint unit tests

### DIFF
--- a/dxcint/README.md
+++ b/dxcint/README.md
@@ -86,9 +86,9 @@ the names in appropriate config file.
 |test category| implementation class name | description |
 | --- | --- | --- | 
 | registered_test | RegisteredTest | always fails, parent of all tests
-| analysis_finished | AnalysisFinished | _validate checks that the analysis succeeded
-| expected_failure | ExpectedFailure | _validate checks that the analysis failed
-| expected_output | ExpectedOutput | _validate checks that the expected result fixture matches analysis outputs
+| analysis_finished | AnalysisFinished | `_validate` checks that the analysis succeeded
+| expected_failure | ExpectedFailure | `_validate` checks that the analysis failed
+| expected_output | ExpectedOutput | `_validate` checks that the expected result fixture matches analysis outputs
 
 There more classes are obtained by combining `mixins` with the above basic classes.
 
@@ -107,7 +107,7 @@ Mixins are designed so that many can be used to extend a category class.
 ### Complex categories
 | test category | implementation class name | comments |
 | --- | --- | --- | 
-| expected_failure_message | ExpectedFailureMessage | ExpectedFailure + ResultsMixin, _validate checks that the analysis failed with an error message specified in results['error']
+| expected_failure_message | ExpectedFailureMessage | ExpectedFailure + ResultsMixin, `_validate` checks that the analysis failed with an error message specified in results['error']
 | extras_analysis_finished | ExtrasAnalysisFinished | AnalysisFinished + ExtrasMixin |
 | extras_expected_output | ExtrasExpectedOutput | ExpectedOutput + ExtrasMixin  |
 | locked_expected_output | LockedExpectedOutput |  ExpectedOutput + LockedMixin, _extract_outputs overriden |
@@ -122,7 +122,7 @@ New test types can be easily added to the framework. First, one needs to add a n
 Then, if this category needs a new behavior when compiling, running and/or validating the test, a new subclass of 
 `RegisteredTest` needs to be implemented. There might be up to 3 methods that might need implementation.
 
-Use **Mixins** to add common functionality to your new test type.
+Use **Mixins** (classes designed for multiple inheritance) to add common functionality to your new test type, put them first in the derived class definition. E.g. `class NewTestClass(Mixin1, Mixin2, AnalysisFinished)`. 
 
 1. **Compilation**. If a test workflow in this new test category should be compiled with a specific combination of dxCompiler flags, 
 the property `exec_id` should be overridden/implemented with passing those compiler arguments to the 

--- a/dxcint/dependencies/config/awscli.json
+++ b/dxcint/dependencies/config/awscli.json
@@ -1,6 +1,6 @@
 {
   "name": "awscli",
   "languages": ["wdl", "cwl"],
-  "version": "2.2.0",
+  "version": "1.25.82",
   "package_manager": "pip"
 }

--- a/dxcint/dxcint/Messenger.py
+++ b/dxcint/dxcint/Messenger.py
@@ -1,6 +1,6 @@
 import dxpy
 
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 from enum import Enum, auto
 
 from dxcint.Context import Context
@@ -88,3 +88,7 @@ class Messenger(object):
             self._state = State.UNKNOWN
 
         return self.state
+
+    def describe_execution(self) -> Dict:
+        """Returns the description of the execution."""
+        return self._execution.describe()

--- a/dxcint/dxcint/Terraform.py
+++ b/dxcint/dxcint/Terraform.py
@@ -140,13 +140,14 @@ class Terraform(object):
         return asset_obj.get("id")
 
     def _create_asset_spec(self, language: str) -> Dict:
-        # spec_exports = [x.export_spec() for x in self._dependencies].remove(None) # this line doesn't do anything
+        spec_exports = [x.export_spec() for x in self._dependencies]
+        spec_exports = [x for x in spec_exports if x]
         exec_depends = [
             {"name": "openjdk-8-jre-headless"},
             {"name": "bzip2"},
             {"name": "jq"},
         ]
-        # + (spec_exports or [])
+        +spec_exports
         asset_spec = {
             "version": self._context.version,
             "name": f"dx{language}rt",

--- a/dxcint/dxcint/testclasses/ExpectedFailureMessage.py
+++ b/dxcint/dxcint/testclasses/ExpectedFailureMessage.py
@@ -18,7 +18,7 @@ class ExpectedFailureMessage(ResultsTestMixin, ExpectedFailure):
     def _validate(self) -> Dict:
         self.messenger.wait_for_completion()
         if self.messenger.state == State.FAIL:
-            failure_msg = dxpy.describe(self.job_id)["failureMessage"]
+            failure_msg = self.messenger.describe_execution()["failureMessage"]
             if failure_msg == self._expected_failure_msg:
                 return {
                     "passed": True,

--- a/dxcint/dxcint/testclasses/ExpectedOutput.py
+++ b/dxcint/dxcint/testclasses/ExpectedOutput.py
@@ -30,7 +30,7 @@ class ExpectedOutput(ResultsTestMixin, RegisteredTest):
         return execution.describe().get("id")
 
     def _extract_outputs(self) -> Dict:
-        desc = dxpy.describe(self.job_id)
+        desc = self.messenger.describe_execution(self.job_id)
         if desc["class"] == "analysis":
             stages = desc["stages"]
             for stage in stages:

--- a/dxcint/dxcint/testclasses/LockedExpectedOutput.py
+++ b/dxcint/dxcint/testclasses/LockedExpectedOutput.py
@@ -9,7 +9,7 @@ class LockedExpectedOutput(LockedMixin, ExpectedOutput):
         super().__init__(*args, **kwargs)
 
     def _extract_outputs(self) -> Dict:
-        desc = dxpy.describe(self.job_id)
+        desc = self.messenger.describe_execution(self.job_id)
         if desc["class"] in ["analysis", "job"]:
             return desc["output"]
         else:

--- a/dxcint/tests/fixtures/resources/mock_category/efm_results.json
+++ b/dxcint/tests/fixtures/resources/mock_category/efm_results.json
@@ -1,0 +1,3 @@
+{
+    "error": "expected error"
+}

--- a/dxcint/tests/fixtures/resources/mock_category/mock_1_extras.json
+++ b/dxcint/tests/fixtures/resources/mock_category/mock_1_extras.json
@@ -1,0 +1,3 @@
+{
+  "mock_1.extra": "extra"
+}

--- a/dxcint/tests/test_ExpectedOutput.py
+++ b/dxcint/tests/test_ExpectedOutput.py
@@ -1,0 +1,10 @@
+import pytest
+from dxcint.Messenger import State
+
+from dxcint.testclasses.ExpectedOutput import ExpectedOutput
+
+# TODO: test all the cases in ExpectedOutput._validate()
+
+
+def test_ExpectedOutput():
+    pytest.fail()

--- a/dxcint/tests/test_mixins.py
+++ b/dxcint/tests/test_mixins.py
@@ -1,0 +1,72 @@
+import os
+import pytest
+from dxcint.Messenger import State
+from dxcint.RegisteredTest import RegisteredTest
+
+from dxcint.mixins.DefaultInstanceMixin import DefaultInstanceMixin
+from dxcint.mixins.ExtrasMixin import ExtrasMixin
+from dxcint.mixins.LockedMixin import LockedMixin
+from dxcint.mixins.ManifestMixin import ManifestMixin
+from dxcint.mixins.ReorgMixin import ReorgMixin
+from dxcint.mixins.ResultsTestMixin import ResultsTestMixin
+from dxcint.mixins.StaticOnlyMixin import StaticOnlyMixin
+from unittest.mock import patch, Mock
+
+
+@patch("subprocess.check_output")
+def test_mixin_composition(context_init):
+    """Test that the compile args mixins can be used together"""
+
+    class SuperMixer(
+        ExtrasMixin,
+        LockedMixin,
+        ManifestMixin,
+        ReorgMixin,
+        StaticOnlyMixin,
+        RegisteredTest,
+    ):
+        pass
+
+    process_mock = Mock()
+    attrs = {"strip.return_value": b"workflow-xxxx"}
+    process_mock.configure_mock(**attrs)
+    hc = SuperMixer("mixer", "mock_category", "mixer", context_init)
+    with patch("subprocess.check_output", return_value=process_mock) as mock_subprocess:
+        mock = hc._compile_executable()
+        compiler_args = mock_subprocess.call_args_list[0].args[0]
+        assert "--extras" in compiler_args
+        assert "-locked" in compiler_args
+        assert "-useManifests" in compiler_args
+        assert "-reorg" in compiler_args
+        assert "static" in compiler_args
+        assert mock == "workflow-xxxx"
+
+
+# TODO
+def test_ExtrasMixin(fixtures_dir, context_init):
+    class ExtrasMixer(ExtrasMixin, RegisteredTest):
+        pass
+
+    em = ExtrasMixer(
+        os.path.join(fixtures_dir, "resources", "mock_category", "mock_1.wdl"),
+        "mock_category",
+        "mock_1",
+        context_init,
+    )
+    with patch("subprocess.check_output") as mock_subprocess:
+        _ = em._compile_executable()
+        assert (
+            os.path.join(
+                fixtures_dir, "resources", "mock_category", "mock_1_extras.json"
+            )
+            in mock_subprocess.call_args_list[0].args[0]
+        )
+        assert "--extras" in mock_subprocess.call_args_list[0].args[0]
+
+
+def test_DefaultInstanceMixin():
+    pytest.fail("Not implemented")
+
+
+def test_ResultsTestMixin():
+    pytest.fail("Not implemented")

--- a/dxcint/tests/test_testclasses.py
+++ b/dxcint/tests/test_testclasses.py
@@ -1,0 +1,107 @@
+import os
+import pytest
+from dxcint.Messenger import State
+
+from dxcint.testclasses.AnalysisFinished import AnalysisFinished
+from dxcint.testclasses.AppExternExpectedOutput import AppExternExpectedOutput
+from dxcint.testclasses.ExpectedFailure import ExpectedFailure
+from dxcint.testclasses.ExpectedFailureMessage import ExpectedFailureMessage
+from dxcint.testclasses.ExpectedOutput import ExpectedOutput
+from dxcint.testclasses.ExternExpectedOutput import ExternExpectedOutput
+from dxcint.testclasses.ExtrasAnalysisFinished import ExtrasAnalysisFinished
+from dxcint.testclasses.LockedExpectedOutput import LockedExpectedOutput
+from dxcint.testclasses.ManifestAnalysisFinished import ManifestAnalysisFinished
+from dxcint.testclasses.ReorgLockedExpectedOutput import ReorgLockedExpectedOutput
+from dxcint.testclasses.StaticDefaultInstanceExpectedOutput import (
+    StaticDefaultInstanceExpectedOutput,
+)
+
+
+class FakeMessenger(object):
+    def __init__(self):
+        self.wait_for_completion = lambda: None
+        self.state = State.NOT_DONE
+        self.describe_execution = lambda: None
+
+
+def test_AnalysisFinished():
+    af = AnalysisFinished(test_name="aftest", src_file="", category="af", context=None)
+    fake_messenger = FakeMessenger()
+    fake_messenger.wait_for_completion = lambda: None
+    af._messenger = fake_messenger
+
+    o1 = {
+        "passed": True,
+        "message": "Execution of the test aftest finished successfully as expected.",
+    }
+    o2 = {
+        "passed": False,
+        "message": "Execution of the test aftest FAILED unexpectedly.",
+    }
+    o3 = {
+        "passed": False,
+        "message": "Execution of the test is in an invalid state: bad_state.",
+    }
+    fake_messenger.state = State.FINISHED
+    assert af._validate() == o1
+    fake_messenger.state = State.FAIL
+    assert af._validate() == o2
+    fake_messenger.state = "bad_state"
+    assert af._validate() == o3
+
+
+def test_ExpectedFailure():
+    ef = ExpectedFailure(test_name="eftest", src_file="", category="ef", context=None)
+    ef._messenger = FakeMessenger()
+    ef._messenger.state = State.FAIL
+    assert ef._validate() == {
+        "passed": True,
+        "message": "Execution of the test eftest failed as expected.",
+    }
+    ef._messenger.state = State.FINISHED
+    assert ef._validate() == {
+        "passed": False,
+        "message": "Execution of the test eftest DID NOT fail as expected.",
+    }
+
+
+def test_ExpectedFailureMessage(fixtures_dir, context_init):
+    efm = ExpectedFailureMessage(
+        src_file=os.path.join(fixtures_dir, "resources", "mock_category", "efm.wdl"),
+        test_name="efm",
+        category="mock_category",
+        context=context_init,
+    )
+    efm._messenger = FakeMessenger()
+    efm._messenger.state = State.FAIL
+    efm._messenger.describe_execution = lambda: {"failureMessage": "expected error"}
+
+    assert efm._validate() == {
+        "passed": True,
+        "message": "Execution of the test efm failed as expected.",
+    }
+    efm._messenger.describe_execution = lambda: {"failureMessage": "unexpected error"}
+    assert efm._validate() == {
+        "passed": False,
+        "message": "Analysis efm results are invalid.\nExpected: expected error.\nReceived: unexpected error",
+    }
+    efm._messenger.state = State.FINISHED
+    assert efm._validate() == {
+        "passed": False,
+        "message": "Execution of the test efm DID NOT fail as expected.",
+    }
+
+
+# TODO classes that are not just comibnation of mixins:
+
+
+def test_AppExternExpectedOutput():
+    pytest.fail()
+
+
+def test_ExternExpectedOutput():
+    pytest.fail()
+
+
+def test_LockedExpectedOutput():
+    pytest.fail()


### PR DESCRIPTION
(test) add unit tests (and declarations of needed tests) for testclasses and mixins (docs) clarify how to use mixins
(fix) Terraform.py: reintroduce spec_exports (same as in APPS-1432) (refactor) move describe api calls to Messenger