### PR TITLE
APPS-1616 delay workspace destr deprecated

### DIFF
--- a/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ApplicationCompiler.scala
@@ -580,7 +580,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
     )
     val (taskMeta, taskDetails) =
       applicationAttributesToNative(applet, defaultTags, extendedDescription)
-    val delayDetails = delayWorkspaceDestructionToNative
     // meta information used for running workflow fragments
     val metaDetails: Map[String, JsValue] =
       applet.kind match {
@@ -645,7 +644,6 @@ case class ApplicationCompiler(typeAliases: Map[String, Type],
     val details: Map[String, JsValue] =
       taskDetails ++
         runSpecDetails ++
-        delayDetails ++
         dxLinks.toMap ++
         metaDetails ++
         auxDetails ++

--- a/compiler/src/main/scala/dx/compiler/ExecutableCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/ExecutableCompiler.scala
@@ -451,14 +451,6 @@ class ExecutableCompiler(extras: Option[Extras],
     (metaDefaults ++ meta ++ summary ++ description, originalName ++ metaDetails ++ whatsNew)
   }
 
-  protected def delayWorkspaceDestructionToNative: Map[String, JsValue] = {
-    if (extras.flatMap(_.delayWorkspaceDestruction).getOrElse(false)) {
-      Map(Constants.DelayWorkspaceDestruction -> JsTrue)
-    } else {
-      Map.empty
-    }
-  }
-
   protected def fileDependenciesFromParam(param: Parameter): Set[String] = {
     val default = param.defaultValue match {
       case Some(f: Value.VFile) => Vector(f.uri)

--- a/compiler/src/main/scala/dx/compiler/WorkflowCompiler.scala
+++ b/compiler/src/main/scala/dx/compiler/WorkflowCompiler.scala
@@ -624,7 +624,6 @@ case class WorkflowCompiler(separateOutputs: Boolean,
       case ExecutableLink(name, _, _, dxExec) =>
         s"link_${name}" -> JsObject(DxUtils.DxLinkKey -> JsString(dxExec.id))
     }.toMap
-    val delayDetails = delayWorkspaceDestructionToNative
     // generate the executable tree
     val execTree = ExecutableTree(executableDict).apply(workflow)
     val execTreeDetails = Map(
@@ -713,7 +712,7 @@ case class WorkflowCompiler(separateOutputs: Boolean,
     }
 
     // Collect details
-    val details = wfMetaDetails ++ sourceDetails ++ dxLinks ++ delayDetails ++ execTreeDetails ++
+    val details = wfMetaDetails ++ sourceDetails ++ dxLinks ++ execTreeDetails ++
       nativeAppDependenciesDetails ++ fileDependenciesDetails ++ dockerRegistryCredentialsUriDetails ++
       staticInstanceTypeSelectionDetails
     val isTopLevel = workflow.level == Level.Top

--- a/compiler/src/main/scala/dx/translator/Extras.scala
+++ b/compiler/src/main/scala/dx/translator/Extras.scala
@@ -177,7 +177,7 @@ object ExtrasJsonProtocol extends DefaultJsonProtocol {
   implicit val defaultReorgSettingsFormat: RootJsonFormat[DefaultReorgSettings] = jsonFormat1(
       DefaultReorgSettings
   )
-  implicit val extrasFormat: RootJsonFormat[Extras] = jsonFormat9(Extras.apply)
+  implicit val extrasFormat: RootJsonFormat[Extras] = jsonFormat8(Extras.apply)
 }
 
 import ExtrasJsonProtocol._
@@ -433,8 +433,7 @@ case class Extras(defaultRuntimeAttributes: Option[Map[String, Value]],
                   perWorkflowDxAttributes: Option[Map[String, DxWorkflowAttrs]],
                   dockerRegistry: Option[DockerRegistry],
                   customReorgAttributes: Option[CustomReorgSettings],
-                  ignoreReuse: Option[Boolean],
-                  delayWorkspaceDestruction: Option[Boolean]) {
+                  ignoreReuse: Option[Boolean]) {
   defaultRuntimeAttributes.foreach { attrs =>
     val unsupportedRuntimeAttrs = attrs.keySet.diff(Extras.RuntimeAttrs)
     if (unsupportedRuntimeAttrs.nonEmpty) {

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -1555,7 +1555,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
       case other =>
         throw new Exception(s"unexpected result ${other}")
     }
-    // make sure the flag is set on the resulting workflow
+    // make sure the flag is ignored in the resulting workflow
     val wfDetails = dxApi.workflow(wfId).describe(Set(Field.Details)).details.get
     val delayWD = wfDetails.asJsObject.fields.get("delayWorkspaceDestruction")
     delayWD shouldBe None

--- a/compiler/src/test/scala/dx/compiler/CompilerTest.scala
+++ b/compiler/src/test/scala/dx/compiler/CompilerTest.scala
@@ -1512,7 +1512,8 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     taskIgnoreReuseFlag shouldBe Some(JsBoolean(true))
   }
 
-  it should "set delayWorkspaceDestruction on applet" taggedAs NativeTest in {
+  // APPS-1616 delayWorkspaceDestruction in extras.json is deprecated
+  it should "ignore delayWorkspaceDestruction in extras for applet" taggedAs NativeTest in {
     val path = pathFromBasename("compiler", "add_timeout.wdl")
     val extrasContent =
       """|{
@@ -1529,15 +1530,16 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
         throw new Exception(s"unexpected result ${other}")
     }
 
-    // make sure the delayWorkspaceDestruction flag is set
+    // make sure the delayWorkspaceDestruction flag is ignored
     val (_, stdout, _) =
       SysUtils.execCommand(s"dx describe ${dxTestProject.id}:${appletId} --json")
     val details = stdout.parseJson.asJsObject.fields("details")
     val delayWD = details.asJsObject.fields.get("delayWorkspaceDestruction")
-    delayWD shouldBe Some(JsTrue)
+    delayWD shouldBe None
   }
 
-  it should "set delayWorkspaceDestruction on workflow" in {
+  // APPS-1616 delayWorkspaceDestruction in extras.json is deprecated
+  it should "ignore delayWorkspaceDestruction in extras for workflow" in {
     val path = pathFromBasename("subworkflows", basename = "trains_station.wdl")
     val extrasContent =
       """|{
@@ -1556,7 +1558,7 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     // make sure the flag is set on the resulting workflow
     val wfDetails = dxApi.workflow(wfId).describe(Set(Field.Details)).details.get
     val delayWD = wfDetails.asJsObject.fields.get("delayWorkspaceDestruction")
-    delayWD shouldBe Some(JsTrue)
+    delayWD shouldBe None
 
     // the flag is set on all the stages
     val execTree = ExecutableTree.fromDxWorkflow(dxApi.workflow(wfId))
@@ -1569,7 +1571,9 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
           .details
           .get
           .asJsObject
-          .fields("delayWorkspaceDestruction")
+          .fields
+          .get("delayWorkspaceDestruction")
+          .orElse(None)
       case applet: String if applet.startsWith("applet-") =>
         dxApi
           .applet(applet)
@@ -1577,10 +1581,12 @@ class CompilerTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
           .details
           .get
           .asJsObject
-          .fields("delayWorkspaceDestruction")
+          .fields
+          .get("delayWorkspaceDestruction")
+          .orElse(None)
       case other => throw new Exception(s"Unknown stage type ${other}")
     }
-    all(delayStages) shouldBe JsBoolean(true)
+    all(delayStages) shouldBe None
   }
 
   it should "Native compile a CWL tool" taggedAs NativeTest in {

--- a/core/src/main/scala/dx/core/Constants.scala
+++ b/core/src/main/scala/dx/core/Constants.scala
@@ -22,7 +22,7 @@ object Constants {
   val InstanceTypeDb = "instanceTypeDB"
   val StaticInstanceType = "staticInstanceType"
   val StaticInstanceTypeSelection = "staticInstanceTypeSelection"
-  val DelayWorkspaceDestruction = "delayWorkspaceDestruction"
+  val DelayWorkspaceDestruction = "delayWorkspaceDestruction" // TODO remove
   val RuntimeAttributes = "runtimeAttrs"
   val PathsAsObjects = "pathsAsObjects"
   val CompilerTag = "dxCompiler"

--- a/doc/ExpertOptions.md
+++ b/doc/ExpertOptions.md
@@ -1159,7 +1159,8 @@ The following first-level keys are accepted in the _extras_ file:
 * `dockerRegistry`: private registry configuration. See [Private registries](#private-registries])
 * `customReorgAttributes`: custom reorganization applet URI and its configuration. See [Adding config file based reorg applet at compilation time](#adding-config-file-based-reorg-applet-at-compilation-time)
 * `ignoreReuse`: boolean value indicating whether to disable [job reuse](#job-reuse)
-* `delayWorkspaceDestruction`: boolean value indicating whether to delay the destruction of the job's temporary workspace after execution. See [Delay workspace destruction](#delay-workspace-destruction)
+* **Deprecated** `delayWorkspaceDestruction`: boolean value.  Ignored in `extras.json` but accepted for backwards 
+compatibility. Use `dx run <YOUR_WORKFLOW> --delay-workspace-destruction` to preserve temporary workspace containers for 3 days.
 
 If one attribute is specified multiple times, its final value will be retrieved from the following sources and the latter (if exists) will override the former: 
 * `defaultTaskDxAttributes`/`defaultWorkflowDxAttributes` in the extras file
@@ -1341,31 +1342,6 @@ By default, job results are [reused](https://documentation.dnanexus.com/user/run
 }
 ```
 This will be applied to the top-level workflow, sub-workflows, and applets during compilation, and used for all jobs/analyses during execution (which is equivalent to using `--ignore-reuse` flag with `dx run`). 
-
-## Delay workspace destruction
-
-When calling a workflow with `dx run`, jobs and analyses launched by this workflow will have their temporary workspaces to store resources and intermediate outputs. By default, when a job or an analysis has transitioned to a terminal state (done, failed, or terminated), its temporary workspace will be destroyed by the system. 
-
-If you wish to delay the destruction of these temporary workspaces and keep them around longer (around 3 days) after executing the workflow, two things need to be done:
-
-1. Add this setting to the top-level of the extras file:
-
-```
-{
-  "delayWorkspaceDestruction" : true
-}
-```
-This will guarantee the workspace containers of all jobs that spawned from the parent jobs (e.g. in scatters) during workflow execution to remain intact after the analysis.
-
-2. When running the workflow use `--delay-workspace-destruction` flag:
-```
-dx run YOUR_WORKFLOW --delay-workspace-destruction
-```
-This will guarantee the root analysis and its stages will have their workspace destruction delayed.
-
-Taking both steps will ensure all of your workflow containers are not immediately destroyed regardless of whether the analysis succeeds or fails, and will allow you to view the data objects stored in the workflow workspace containers for debugging purposes.
-
-To learn about jobs' workspaces used during execution, please refer to [the official DNAnexus documentation](https://documentation.dnanexus.com/user/running-apps-and-workflows/job-lifecycle#example-execution-tree).
 
 # Handling intermediate workflow outputs
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -272,6 +272,7 @@ ci_test_list = [
     "cat",
 ]
 
+# TODO - migrate to dxcint. Not automated, no regression monitored
 special_flags_list = [
     "add2",  # test the ignoreReuse flag
     "add_many",  # tests the delayWorkspaceDestruction flag

--- a/test/special_flags/add2_extras.json
+++ b/test/special_flags/add2_extras.json
@@ -1,4 +1,3 @@
 {
-  "ignoreReuse": true,
-  "delayWorkspaceDestruction" : true
+  "ignoreReuse": true
 }

--- a/test/special_flags/add_many_extras.json
+++ b/test/special_flags/add_many_extras.json
@@ -1,3 +1,0 @@
-{
-  "delayWorkspaceDestruction" : true
-}

--- a/test/special_flags/inc_range_extras.json
+++ b/test/special_flags/inc_range_extras.json
@@ -1,3 +1,0 @@
-{
-  "delayWorkspaceDestruction" : true
-}


### PR DESCRIPTION
Deprecated the `delayWorkspaceDestruction`. Currently `run_tests.py` does not monitor regressions of any special flags in `extras.json` are monitored. Those tests in [special_flags](https://github.com/dnanexus/dxCompiler/blob/d292c689717bd7df2517da175e212a53e4cdb160/scripts/run_tests.py#L276) are tracking successful workflow runs and comparing them to the outputs, but not tracking the job descriptions. Manual tests were performed (see the ticket) where I deleted the flag `delayWorkspaceDestruction` in the `extras.json` of the respective integration tests. But these situations have to be migrated to dxCint asap.