### PR TITLE
APPS-912 version error msg fix

### DIFF
--- a/core/src/test/resources/bugs/apps_912_version_error_msg_fix.wdl
+++ b/core/src/test/resources/bugs/apps_912_version_error_msg_fix.wdl
@@ -1,0 +1,27 @@
+task apps_912_t01 {
+    input {
+        String s
+    }
+    command <<<
+        cd .
+    >>>
+
+    output {
+        String res = s+s
+    }
+}
+
+
+workflow apps_912 {
+    input {
+        Array[String] strings
+    }
+    scatter (s in strings) {
+        call apps_912_t01 {
+            input: s = s
+        }
+    }
+    output {
+        Array[String] doubled_strings = apps_912_t01.res
+    }
+}

--- a/core/src/test/scala/dx/core/languages/wdl/VersionSupportTest.scala
+++ b/core/src/test/scala/dx/core/languages/wdl/VersionSupportTest.scala
@@ -1,0 +1,22 @@
+package dx.core.languages.wdl
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wdlTools.syntax.SyntaxException
+
+import java.nio.file.{Path, Paths}
+
+class VersionSupportTest extends AnyFlatSpec with Matchers {
+
+  private def pathFromBasename(dir: String, basename: String): Path = {
+    Paths.get(getClass.getResource(s"/${dir}/${basename}").getPath)
+  }
+
+  "VersionSupport" should "throw a relevant exception if wdl source doesn't have version declaration" in {
+    val thrown = the[SyntaxException] thrownBy
+      VersionSupport.fromSourceFile(pathFromBasename("bugs", "apps_912_version_error_msg_fix.wdl"))
+    thrown.getCause.getMessage should include(
+        "Draft 2 version of WDL should not contain a formal `input` section"
+    )
+  }
+}


### PR DESCRIPTION
Adds compiler unit test for checking correct message for errors in `draft-2` syntax.
Dependent on https://github.com/dnanexus/wdlTools/pull/246