### PR TITLE
APPS-2161 Update release.yml to use dnanexusappstestrobot docker account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           ./scripts/build_all_releases.sh \
               --staging-token $DX_STAGING_RELEASE_TOKEN \
               --production-token $DX_PROD_RELEASE_TOKEN \
-              --docker-user dnanexusdxcompiler \
+              --docker-user dnanexusappstestrobot \
               --docker-password $DOCKERHUB_TOKEN \
               --force \
               --branch $TARGET_BRANCH


### PR DESCRIPTION
```
Summary: the apps team wants a new docker account named dnanexus_apps_test_robot.
However we are at 70/71 licenses used for Dockerhub and since the existing dxcompiler account is managed by the apps team already it makes sense to use that existing account for all apps team work on docker and not have an account for each project.

If we're just worried about the user name we can remove the dxcompiler account and invite the new dnanexus_apps_test_robot account to replace it but that seems like a lot of work (swapping all tokens, uploads, etc) for a name change. Unfortunately dockerhub does not currently support changing usernames (only emails).

From a security perspective the less service accounts we have to monitor and keep track of the better as well.
```

tl;dr The IT team recommended us to switch to one under the dnanexus_apps_robot group account and use it for general purpose for the team (replacing the dxcompiler one). 