### PR TITLE
DEVEX-2419 HOTFIX release dxCompiler 2.11.8

### DIFF
--- a/scripts/docker_image/docker.env
+++ b/scripts/docker_image/docker.env
@@ -1,3 +1,3 @@
 # Specify the dxCompiler version from
 # https://github.com/dnanexus/dxCompiler/releases
-VERSION=2.11.6
+VERSION=2.11.8

--- a/scripts/docker_image/docker_test.env
+++ b/scripts/docker_image/docker_test.env
@@ -1,0 +1,3 @@
+# Specify the dxCompiler version from one of the earlier releases
+# https://github.com/dnanexus/dxCompiler/releases
+VERSION=2.11.6

--- a/scripts/docker_image/test.sh
+++ b/scripts/docker_image/test.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Find the root directory of the distribution, regardless of where
 # the script is called from
 base_dir=$(dirname "$0")
-source "${base_dir}/docker.env"
+source "${base_dir}/docker_test.env"
 
 if [[ -z "${VERSION}" ]]; then
   echo "Specify the dxCompiler version in docker.env"


### PR DESCRIPTION

(fix) docker.env - has to be current or it can't build 
(fix) docker_test.env - has to be separated because currently being released version is not yet published 
(fix) test.sh - point to another .env for test