### PR TITLE
APPS-3982 - Removing maxSpotTries in expected output test case

### DIFF
--- a/dxcint/resources/expected_flags/apps_1647_dx_restart_results.json
+++ b/dxcint/resources/expected_flags/apps_1647_dx_restart_results.json
@@ -4,11 +4,9 @@
     "restartOn": {
       "UnresponsiveWorker": 3,
       "ExecutionError": 3
-    },
-    "maxSpotTries": 1
+    }
   },
   "apps_1647_dx_restart.apps_1647_dx_restart_frag_stage-0.executionPolicy": {
-    "maxSpotTries": 1,
     "restartOn": {
       "UnresponsiveWorker": 2,
       "JMInternalError": 1,


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/APPS-3982

All DNAnexus users are no longer able to see maxSpotTries field
Now we need to removing maxSpotTries in expected output test case