### PR TITLE
APPS-3984-Remove-Bahrain-Region

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add support for AppInsufficientResourceError in executionPolicy.restartOn
+* Removing me-south-1 region 
 
 ## 2.15.0 2025-09-29
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -39,7 +39,7 @@ RELEASE_DICT = {
     "aws:eu-west-2": "dxCompiler_London",
     "aws:eu-west-2-g": "dxCompiler_Europe_London",
     "azure:uksouth-ofh": "dxCompiler_OFH_TRE_London",
-    "aws:me-south-1": "dxCompiler_Bahrain",
+    # "aws:me-south-1": "dxCompiler_Bahrain",  # Bahrain region no longer supported
     "oci:us-ashburn-1": "dxCompiler_Ashburn",
 }
 

--- a/scripts/dxcompiler_copy/dxapp.json
+++ b/scripts/dxcompiler_copy/dxapp.json
@@ -100,13 +100,13 @@
         }
       }
     },
-    "aws:me-south-1": {
+    /*"aws:me-south-1": {
       "systemRequirements": {
         "*": {
           "instanceType": "mem1_ssd1_v2_x2"
         }
       }
-    },
+    },*/
     "azure:uksouth-ofh": {
       "systemRequirements": {
         "*": {

--- a/scripts/dxcompiler_copy/dxapp.json
+++ b/scripts/dxcompiler_copy/dxapp.json
@@ -100,13 +100,6 @@
         }
       }
     },
-    /*"aws:me-south-1": {
-      "systemRequirements": {
-        "*": {
-          "instanceType": "mem1_ssd1_v2_x2"
-        }
-      }
-    },*/
     "azure:uksouth-ofh": {
       "systemRequirements": {
         "*": {

--- a/scripts/dxcompiler_copy/dxapp.json
+++ b/scripts/dxcompiler_copy/dxapp.json
@@ -3,7 +3,7 @@
   "title": "Copy File",
   "summary": "Copy a file to a different region",
   "dxapi": "1.0.0",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "billTo": "org-dnanexus_apps",
   "developers": [
     "org-dnanexus_apps"
@@ -116,7 +116,7 @@
     }
   },
   "details": {
-    "whatsNew": "* 0.2.0: Update running environment to Ubuntu 24.04 \n * 0.1.0: Added new OCI Ashburn region \n * 0.0.7: Fixed instance types for Azure regions\n * 0.0.6: Added new Bahrain AWS region aws:me-south-1\n * 0.0.5: updated azure instances to v2 for OFH region\n * 0.0.3: Added new London OFH region\n * 0.0.2: Added new London region."
+    "whatsNew": "* 0.2.1: Removed Bahrain AWS region aws:me-south-1 \n * 0.2.0: Update running environment to Ubuntu 24.04 \n * 0.1.0: Added new OCI Ashburn region \n * 0.0.7: Fixed instance types for Azure regions\n * 0.0.6: Added new Bahrain AWS region aws:me-south-1\n * 0.0.5: updated azure instances to v2 for OFH region\n * 0.0.3: Added new London OFH region\n * 0.0.2: Added new London region."
   },
   "access": {
     "network": [

--- a/scripts/multi_region_tests.py
+++ b/scripts/multi_region_tests.py
@@ -29,7 +29,7 @@ projects = ["dxCompiler",
             "dxCompiler_London",
             "dxCompiler_Europe_London",
             "dxCompiler_OFH_TRE_London",
-            "dxCompiler_Bahrain",
+            # "dxCompiler_Bahrain",  # Bahrain region no longer supported
             "dxCompiler_Ashburn"]
 
 target_folder = "/release_test"


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/APPS-3984

We not support Bahrain region anymore. But DxCompiler still has Bahrain region in the building release process. Now need to remove it