### PR TITLE
APPS-3990- Skip London region DxComplier

### DIFF
--- a/.github/workflows/copy_asset_to_region.yml
+++ b/.github/workflows/copy_asset_to_region.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip
           pip3 install --upgrade pip setuptools==76.0.0
-          pip3 install dxpy==0.393.0 pyOpenSSL==25.0.0
+          pip3 install dxpy pyOpenSSL==25.0.0
           export PATH="$PATH:$HOME/.local/bin"
       - name: Copy assets to region (staging)
         if: ${{ github.event.inputs.environment == 'staging' }}

--- a/.github/workflows/copy_asset_to_region.yml
+++ b/.github/workflows/copy_asset_to_region.yml
@@ -1,0 +1,70 @@
+name: Copy Asset to Region
+# Run this workflow to backfill ALL runtime assets (wdl + cwl) into a region
+# that was skipped during the original release (e.g. because it was temporarily
+# unavailable). Once this workflow succeeds the region is fully supported for
+# the given version — no further action is needed.
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'dxCompiler release version to backfill (e.g. 2.11.0)'
+        required: true
+      region:
+        description: 'Destination region (e.g. aws:eu-west-2)'
+        required: true
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        default: 'production'
+        options:
+          - 'production'
+          - 'staging'
+
+permissions:
+  contents: read
+
+jobs:
+  copy-asset:
+    name: Copy assets to ${{ github.event.inputs.region }} (${{ github.event.inputs.environment }})
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # performance optimizations https://abbbi.github.io/actions/
+      - uses: abbbi/github-actions-tune@81fb919e588c20b7ab52b2cac097d2efd765c714 # v1
+      - name: Install dxpy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip
+          pip3 install --upgrade pip setuptools==76.0.0
+          pip3 install dxpy==0.393.0 pyOpenSSL==25.0.0
+          export PATH="$PATH:$HOME/.local/bin"
+      - name: Copy assets to region (staging)
+        if: ${{ github.event.inputs.environment == 'staging' }}
+        env:
+          DX_TOKEN: ${{ secrets.DX_STAGING_ROBOT_TOKEN }}
+        run: |
+          export PATH="$PATH:$HOME/.local/bin"
+          for LANG in wdl cwl; do
+            echo "=== Copying $LANG asset ==="
+            python3 scripts/copy_asset_to_region.py \
+              --version ${{ github.event.inputs.release-version }} \
+              --region "${{ github.event.inputs.region }}" \
+              --language $LANG \
+              --token $DX_TOKEN
+          done
+      - name: Copy assets to region (production)
+        if: ${{ github.event.inputs.environment == 'production' }}
+        env:
+          DX_TOKEN: ${{ secrets.DX_PROD_RELEASE_TOKEN }}
+        run: |
+          export PATH="$PATH:$HOME/.local/bin"
+          for LANG in wdl cwl; do
+            echo "=== Copying $LANG asset ==="
+            python3 scripts/copy_asset_to_region.py \
+              --version ${{ github.event.inputs.release-version }} \
+              --region "${{ github.event.inputs.region }}" \
+              --language $LANG \
+              --token $DX_TOKEN
+          done

--- a/.github/workflows/copy_asset_to_region.yml
+++ b/.github/workflows/copy_asset_to_region.yml
@@ -40,24 +40,9 @@ jobs:
           pip3 install --upgrade pip setuptools==76.0.0
           pip3 install dxpy pyOpenSSL==25.0.0
           export PATH="$PATH:$HOME/.local/bin"
-      - name: Copy assets to region (staging)
-        if: ${{ github.event.inputs.environment == 'staging' }}
+      - name: Copy assets to region
         env:
-          DX_TOKEN: ${{ secrets.DX_STAGING_ROBOT_TOKEN }}
-        run: |
-          export PATH="$PATH:$HOME/.local/bin"
-          for LANG in wdl cwl; do
-            echo "=== Copying $LANG asset ==="
-            python3 scripts/copy_asset_to_region.py \
-              --version ${{ github.event.inputs.release-version }} \
-              --region "${{ github.event.inputs.region }}" \
-              --language $LANG \
-              --token $DX_TOKEN
-          done
-      - name: Copy assets to region (production)
-        if: ${{ github.event.inputs.environment == 'production' }}
-        env:
-          DX_TOKEN: ${{ secrets.DX_PROD_RELEASE_TOKEN }}
+          DX_TOKEN: ${{ github.event.inputs.environment == 'staging' && secrets.DX_STAGING_ROBOT_TOKEN || secrets.DX_PROD_RELEASE_TOKEN }}
         run: |
           export PATH="$PATH:$HOME/.local/bin"
           for LANG in wdl cwl; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,16 +163,16 @@ jobs:
           export PATH="$PATH:$HOME/.local/bin"
           export TARGET_BRANCH=`echo ${{ github.ref }} | sed -e 's/refs\/heads\///g'`
           SKIP_REGIONS="${{ github.event.inputs.skip-clone-regions }}"
-          SKIP_FLAG=""
+          SKIP_FLAGS=""
           if [[ -n "$SKIP_REGIONS" ]]; then
-            SKIP_FLAG="--skip-clone-regions $SKIP_REGIONS"
+            SKIP_FLAGS="--skip-clone-regions $SKIP_REGIONS"
           fi
           ./scripts/build_all_releases.sh \
               --staging-token $DX_STAGING_RELEASE_TOKEN \
               --production-token $DX_PROD_RELEASE_TOKEN \
               --force \
               --branch $TARGET_BRANCH \
-              $SKIP_FLAG
+              $SKIP_FLAGS
       - name: Extract release notes
         id: update-release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
         description: 'Should run large integration tests (false/true; default: true)'
         required: false
         default: 'true'
+      skip-clone-regions:
+        description: 'Comma-separated regions to skip asset cloning (e.g. aws:eu-west-2). Region is still included in JAR config.'
+        required: false
+        default: ''
 permissions:
   contents: write
   packages: read
@@ -158,11 +162,17 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.local/bin"
           export TARGET_BRANCH=`echo ${{ github.ref }} | sed -e 's/refs\/heads\///g'`
+          SKIP_REGIONS="${{ github.event.inputs.skip-clone-regions }}"
+          SKIP_FLAG=""
+          if [[ -n "$SKIP_REGIONS" ]]; then
+            SKIP_FLAG="--skip-clone-regions $SKIP_REGIONS"
+          fi
           ./scripts/build_all_releases.sh \
               --staging-token $DX_STAGING_RELEASE_TOKEN \
               --production-token $DX_PROD_RELEASE_TOKEN \
               --force \
-              --branch $TARGET_BRANCH
+              --branch $TARGET_BRANCH \
+              $SKIP_FLAG
       - name: Extract release notes
         id: update-release
         run: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 * Add support for AppInsufficientResourceError in executionPolicy.restartOn
-* Removing me-south-1 region 
+* Removing me-south-1 region
+* Added `--skip-clone-regions` flag to `build_release.py` and `build_all_releases.sh` to allow skipping asset cloning into unavailable regions during release; skipped regions remain in the JAR config
+* Added `scripts/copy_asset_to_region.py` script and `.github/workflows/copy_asset_to_region.yml` workflow to backfill a skipped region once it recovers
 
 ## 2.15.0 2025-09-29
 

--- a/scripts/build_all_releases.sh
+++ b/scripts/build_all_releases.sh
@@ -7,6 +7,7 @@ dry_run=""
 build_flags=""
 staging_token=""
 production_token=""
+skip_clone_regions=""
 
 # https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
 # Get the source directory of the distribution
@@ -48,14 +49,23 @@ function basic_checks {
 }
 
 function build {
+    local skip_regions_flag=""
+    if [[ -n "$skip_clone_regions" ]]; then
+        skip_regions_flag="--skip-clone-regions $skip_clone_regions"
+    fi
+
     # build the release on staging
     echo "building staging release"
     dx login --staging --token $staging_token --noprojects
-    $top_dir/scripts/build_release.py --multi-region $build_flags
+    $top_dir/scripts/build_release.py --multi-region $build_flags $skip_regions_flag
 
     ## test that it actually works
     echo "running multi region tests on staging"
-    $top_dir/scripts/multi_region_tests.py
+    if [[ -n "$skip_clone_regions" ]]; then
+        $top_dir/scripts/multi_region_tests.py --skip-regions $skip_clone_regions
+    else
+        $top_dir/scripts/multi_region_tests.py
+    fi
     #$top_dir/scripts/proxy_test.py
 
     echo "leave staging"
@@ -64,7 +74,7 @@ function build {
     ## build on production
     echo "building on production"
     dx login --token $production_token --noprojects
-    $top_dir/scripts/build_release.py --multi-region $build_flags
+    $top_dir/scripts/build_release.py --multi-region $build_flags $skip_regions_flag
 }
 
 function usage_die
@@ -75,6 +85,7 @@ function usage_die
     echo "  --staging-token <string>: an auth token for the staging environment"
     echo "  --production-token <string>: an auth token for the production environment"
     echo "  --branch <string>: branch to build from (default=main)"
+    echo "  --skip-clone-regions <string>: comma-separated regions to skip asset cloning (e.g. aws:eu-west-2)"
     exit 1
 }
 
@@ -99,6 +110,10 @@ function parse_cmd_line {
                 ;;
             --branch)
                 target_branch=$2
+                shift
+                ;;
+            --skip-clone-regions)
+                skip_clone_regions=$2
                 shift
                 ;;
             *)

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -4,7 +4,6 @@
 
 import argparse
 import dxpy
-from dxpy.exceptions import DXJobFailureError
 import json
 import os
 import subprocess
@@ -27,150 +26,11 @@ TEST_DICT = {
     "aws:us-east-1" :  "dxCompiler_playground"
 }
 
-# To add region R, create a project for it, dxCompiler_R, and add
-# a mapping to the lists
-#    R : dxCompiler_R
-RELEASE_DICT = {
-    "aws:us-east-1" :  "dxCompiler",
-    "aws:ap-southeast-2" : "dxCompiler_Sydney",
-    "azure:westus" : "dxCompiler_Azure",
-    "azure:westeurope" : "dxCompiler_Amsterdam",
-    "aws:eu-central-1" : "dxCompiler_Berlin",
-    "aws:eu-west-2": "dxCompiler_London",
-    "aws:eu-west-2-g": "dxCompiler_Europe_London",
-    "azure:uksouth-ofh": "dxCompiler_OFH_TRE_London",
-    # "aws:me-south-1": "dxCompiler_Bahrain",  # Bahrain region no longer supported
-    "oci:us-ashburn-1": "dxCompiler_Ashburn",
-}
+# Load region-to-project mapping from the shared config file.
+# To add or retire a region, edit scripts/regions.json instead of this file.
+with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "regions.json")) as _f:
+    RELEASE_DICT = json.load(_f)["regions"]
 
-# 1. Use the clone-asset app to copy the file into [region].
-# 2. Create a record pointing to the hidden file in [region].
-def _clone_asset_into_region(region, dest_proj_id, asset_file_name, dest_folder, url):
-    """
-    Clone file into a remote region.
-    """
-    dxjob = COPY_FILE_APP.run(app_input = { "url" : url,
-                                            "folder" : dest_folder,
-                                            "filename" : asset_file_name },
-                              name = "copy to region {}".format(region),
-                              project = dest_proj_id,
-                              priority = "high") # added high priority because OFH region, where it takes 3 reruns to build.
-    print('{region}: {job_id}'.format(region=region, job_id=dxjob.get_id()),
-          file=sys.stderr)
-    return dxjob
-
-
-def _wait_for_completion(jobs):
-    print("awaiting completion ...")
-    # wait for analysis to finish while working around Travis 10m console inactivity timeout
-    noise = subprocess.Popen(["/bin/bash", "-c", "while true; do sleep 60; date; done"])
-    success = True
-    try:
-        for j in jobs:
-            try:
-                j.wait_on_done()
-            except DXJobFailureError:
-                print("job {} failed".format(j.get_id()))
-                success = False
-    finally:
-        noise.kill()
-    print("done")
-    return success
-
-def _clone_to_all_regions(region2projid, regions, asset_file_name, folder, url):
-    jobs = []
-    for region in regions:
-        dest_proj_id = region2projid[region]
-        results = list(dxpy.find_data_objects(classname = "file",
-                                              visibility = "hidden",
-                                              name = asset_file_name,
-                                              project = dest_proj_id,
-                                              folder = folder))
-        file_ids = [p["id"] for p in results]
-        nfiles = len(file_ids)
-        if nfiles == 1:
-            continue
-        if nfiles > 1:
-            print("cleanup in {}, found {} files instead of 0/1".format(dest_proj_id, nfiles))
-            dxpy.DXProject(dest_proj_id).remove_objects(file_ids)
-        dxjob = _clone_asset_into_region(region,
-                                         dest_proj_id,
-                                         asset_file_name,
-                                         folder,
-                                         url)
-        jobs.append(dxjob)
-    return jobs
-
-def _clone_asset(record, folder, regions, project_dict):
-    """
-    This function will attempt to clone the given record into all of the given regions.
-    It will return a dictionary with the regions as keys and the record-ids of the
-    corresponding asset as the values.  If an asset is not able to be created in a given
-    region, the value will be set to None.
-    """
-    # Get the asset record
-    fid = record.get_details()['archiveFileId']['$dnanexus_link']
-    curr_region = dxpy.describe(record.project)['region']
-
-    # Only run once per region
-    regions = set(regions) - set([curr_region])
-    if len(regions) == 0:
-        # there is nothing to do
-        return
-
-    app_supported_regions = set(COPY_FILE_APP.describe()['regionalOptions'].keys())
-    if len(regions - app_supported_regions) > 0:
-        print('Currently no support for the following region(s): [{regions}]'
-              .format(regions=', '.join(regions - app_supported_regions)),
-              file=sys.stderr)
-        sys.exit(1)
-
-    # Get information about the asset
-    asset_properties = record.get_properties()
-    asset_properties['cloned_from'] = record.get_id()
-    asset_file_name = dxpy.describe(fid)['name']
-    url = dxpy.DXFile(fid).get_download_url(preauthenticated=True,
-                                            project=dxpy.DXFile.NO_PROJECT_HINT,
-                                            duration=URL_DURATION)[0]
-
-    # setup target folders
-    region2projid = {}
-    for region in regions:
-        dest_proj = util.get_project(project_dict[region])
-        dest_proj.new_folder(folder, parents=True)
-        region2projid[region] = dest_proj.get_id()
-    print(region2projid)
-
-    # Fire off a clone process for each region
-    # Wait for the cloning to complete
-    for i in [1, 2, 3]:
-        jobs = _clone_to_all_regions(region2projid, regions, asset_file_name, folder, url)
-        retval = _wait_for_completion(jobs)
-        if retval:
-            break
-
-    # make records for each file
-    for region in regions:
-        dest_proj_id = region2projid[region]
-        print(f"Cloning asset into {region}, project: {dest_proj_id}, asset file name: {asset_file_name}")
-        results = list(dxpy.find_data_objects(classname="file",
-                                              visibility="hidden",
-                                              name=asset_file_name,
-                                              project=dest_proj_id,
-                                              folder=folder))
-        file_ids = [p["id"] for p in results]
-        if len(file_ids) == 0:
-            raise RuntimeError("Found no files {}:{}/{}".format(dest_proj_id, folder, asset_file_name))
-        if len(file_ids) > 1:
-            raise RuntimeError("Found {} files {}:{}/{}, instead of just one"
-                               .format(len(file_ids), dest_proj_id, folder, asset_file_name))
-        dest_asset = dxpy.new_dxrecord(name=record.name,
-                                       types=['AssetBundle'],
-                                       details={'archiveFileId': dxpy.dxlink(file_ids[0])},
-                                       properties=record.get_properties(),
-                                       project=dest_proj_id,
-                                       folder=folder,
-                                       close=True)
 
 
 def main():
@@ -273,7 +133,7 @@ def main():
                 if dest_asset == None:
                     target_regions.append(dest_region)
 
-            _clone_asset(home_rec, folder, target_regions, project_dict)
+            util.clone_asset(COPY_FILE_APP, home_rec, folder, target_regions, project_dict)
 
 if __name__ == '__main__':
     main()

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -187,17 +187,40 @@ def main():
                            help="Don't build any artifacts",
                            action='store_true',
                            default=False)
+    argparser.add_argument("--skip-clone-regions",
+                           help="Comma-separated regions to skip asset cloning (e.g. aws:eu-west-2). "
+                                "Region is still included in JAR config.",
+                           default="")
     args = argparser.parse_args()
 
     # build multi-region jar for releases, or
     # if explicitly specified
     multi_region = args.multi_region
+    # strip whitespace around each entry to tolerate "aws:eu-west-2, azure:westeurope"
+    skip_clone_regions = (
+        set(r.strip() for r in args.skip_clone_regions.split(",") if r.strip())
+        if args.skip_clone_regions else set()
+    )
 
     # Choose which dictionary to use
     if multi_region:
         project_dict = RELEASE_DICT
     else:
         project_dict = TEST_DICT
+
+    # Validate skip_clone_regions against known regions and disallow home region
+    if skip_clone_regions:
+        unknown = skip_clone_regions - set(project_dict.keys())
+        if unknown:
+            print("ERROR: Unknown region(s) in --skip-clone-regions: {}. "
+                  "Known regions: {}".format(", ".join(sorted(unknown)),
+                                             ", ".join(sorted(project_dict.keys()))),
+                  file=sys.stderr)
+            sys.exit(1)
+        if HOME_REGION in skip_clone_regions:
+            print("ERROR: Cannot skip the home region ({}).".format(HOME_REGION),
+                  file=sys.stderr)
+            sys.exit(1)
 
     project = util.get_project(project_dict[HOME_REGION])
     print("project: {} ({})".format(project.name, project.get_id()))
@@ -239,9 +262,12 @@ def main():
             home_rec = dxpy.DXRecord(asset_desc.asset_id)
             all_regions = project_dict.keys()
 
-            # Leave only regions where the asset is missing
+            # Leave only regions where the asset is missing and not explicitly skipped
             target_regions = []
             for dest_region in all_regions:
+                if dest_region in skip_clone_regions:
+                    print("Skipping asset clone for region: {}".format(dest_region), file=sys.stderr)
+                    continue
                 dest_proj = util.get_project(project_dict[dest_region])
                 dest_asset = util.find_asset(dest_proj, folder, lang)
                 if dest_asset == None:

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -15,7 +15,6 @@ import util
 here = os.path.dirname(sys.argv[0])
 top_dir = os.path.dirname(os.path.abspath(here))
 
-HOME_REGION = "aws:us-east-1"
 URL_DURATION = 60 * 60 * 24
 SLEEP_TIME = 5
 COPY_FILE_APP_NAME = "dxwdl_copy"
@@ -77,12 +76,12 @@ def main():
                                              ", ".join(sorted(project_dict.keys()))),
                   file=sys.stderr)
             sys.exit(1)
-        if HOME_REGION in skip_clone_regions:
-            print("ERROR: Cannot skip the home region ({}).".format(HOME_REGION),
+        if util.HOME_REGION in skip_clone_regions:
+            print("ERROR: Cannot skip the home region ({}).".format(util.HOME_REGION),
                   file=sys.stderr)
             sys.exit(1)
 
-    project = util.get_project(project_dict[HOME_REGION])
+    project = util.get_project(project_dict[util.HOME_REGION])
     print("project: {} ({})".format(project.name, project.get_id()))
 
     # Figure out what the current version is

--- a/scripts/copy_asset_to_region.py
+++ b/scripts/copy_asset_to_region.py
@@ -18,155 +18,22 @@ If --token is not supplied the script uses the currently active dx login session
 from __future__ import print_function
 
 import argparse
-import subprocess
+import json
 import sys
 import os
 
 import dxpy
-from dxpy.exceptions import DXJobFailureError
-
-here = os.path.dirname(sys.argv[0])
-top_dir = os.path.dirname(os.path.abspath(here))
+import util
 
 COPY_FILE_APP_NAME = "dxwdl_copy"
-URL_DURATION = 60 * 60 * 24  # 24 hours
 
 HOME_REGION = "aws:us-east-1"
 HOME_PROJECT_NAME = "dxCompiler"
 
-# Mapping from region name to destination project name
-REGION_TO_PROJECT = {
-    "aws:us-east-1":      "dxCompiler",
-    "aws:ap-southeast-2": "dxCompiler_Sydney",
-    "azure:westus":       "dxCompiler_Azure",
-    "azure:westeurope":   "dxCompiler_Amsterdam",
-    "aws:eu-central-1":   "dxCompiler_Berlin",
-    "aws:eu-west-2":      "dxCompiler_London",
-    "aws:eu-west-2-g":    "dxCompiler_Europe_London",
-    "azure:uksouth-ofh":  "dxCompiler_OFH_TRE_London",
-    "oci:us-ashburn-1":   "dxCompiler_Ashburn",
-}
-
-
-def get_project(project_name):
-    """Find a DNAnexus project by name."""
-    try:
-        project = dxpy.DXProject(project_name)
-        return project
-    except dxpy.DXError:
-        pass
-    results = list(dxpy.find_projects(name=project_name, return_handler=True, level="VIEW"))
-    if len(results) == 0:
-        return None
-    if len(results) == 1:
-        return results[0]
-    # Prefer owned projects
-    owned = [r for r in results if r.describe()["level"] == "ADMINISTER"]
-    if len(owned) == 1:
-        return owned[0]
-    raise RuntimeError("Found {} projects named '{}'".format(len(results), project_name))
-
-
-def find_asset(project, folder, language):
-    """Return the AssetBundle record for the given language in the given folder, or None."""
-    asset_name = "dx{}rt".format(language.upper())
-    assets = list(dxpy.search.find_data_objects(
-        classname="record",
-        project=project.get_id(),
-        name=asset_name,
-        folder=folder,
-        return_handler=True,
-    ))
-    if len(assets) == 0:
-        return None
-    if len(assets) == 1:
-        return assets[0]
-    raise RuntimeError("Found {} records named '{}' in {}:{}".format(
-        len(assets), asset_name, project.name, folder))
-
-
-def _wait_for_job(job):
-    """Block until job completes, printing timestamps every 60 s to keep CI alive."""
-    noise = subprocess.Popen(["/bin/bash", "-c", "while true; do sleep 60; date; done"])
-    try:
-        job.wait_on_done()
-    finally:
-        noise.kill()
-
-
-def clone_asset(copy_app, source_record, dest_proj, folder, language):
-    """
-    Clone the asset from source_record into dest_proj/folder using the dxwdl_copy app.
-    Returns the newly created AssetBundle record in the destination project.
-    """
-    asset_name = "dx{}rt".format(language.upper())
-
-    # Check if the asset already exists in the destination
-    existing = find_asset(dest_proj, folder, language)
-    if existing is not None:
-        print("Asset '{}' already exists in {}:{} ({}). Nothing to do.".format(
-            asset_name, dest_proj.name, folder, existing.get_id()))
-        return existing
-
-    # Get the underlying file from the source record
-    fid = source_record.get_details()['archiveFileId']['$dnanexus_link']
-    asset_file_name = dxpy.describe(fid)['name']
-
-    print("Generating pre-authenticated download URL for {} ...".format(asset_file_name))
-    url = dxpy.DXFile(fid).get_download_url(
-        preauthenticated=True,
-        project=dxpy.DXFile.NO_PROJECT_HINT,
-        duration=URL_DURATION,
-    )[0]
-
-    dest_proj.new_folder(folder, parents=True)
-    dest_region = dxpy.describe(dest_proj.get_id())['region']
-
-    print("Launching copy job in region {} (project: {} {}) ...".format(
-        dest_region, dest_proj.name, dest_proj.get_id()))
-    dxjob = copy_app.run(
-        app_input={"url": url, "folder": folder, "filename": asset_file_name},
-        name="copy {} to {}".format(asset_name, dest_region),
-        project=dest_proj.get_id(),
-        priority="high",
-    )
-    print("Copy job: {}".format(dxjob.get_id()))
-
-    print("Waiting for copy job to complete ...")
-    _wait_for_job(dxjob)
-    print("Copy job finished.")
-
-    # Find the uploaded file
-    results = list(dxpy.find_data_objects(
-        classname="file",
-        visibility="hidden",
-        name=asset_file_name,
-        project=dest_proj.get_id(),
-        folder=folder,
-    ))
-    file_ids = [p["id"] for p in results]
-    if len(file_ids) == 0:
-        raise RuntimeError("Copy job succeeded but no file found at {}:{}/{}".format(
-            dest_proj.get_id(), folder, asset_file_name))
-    if len(file_ids) > 1:
-        raise RuntimeError("Found {} files at {}:{}/{}, expected exactly one".format(
-            len(file_ids), dest_proj.get_id(), folder, asset_file_name))
-
-    # Create the AssetBundle record pointing at the copied file
-    asset_properties = source_record.get_properties()
-    asset_properties['cloned_from'] = source_record.get_id()
-
-    dest_record = dxpy.new_dxrecord(
-        name=source_record.name,
-        types=['AssetBundle'],
-        details={'archiveFileId': dxpy.dxlink(file_ids[0])},
-        properties=asset_properties,
-        project=dest_proj.get_id(),
-        folder=folder,
-        close=True,
-    )
-    print("Created AssetBundle record: {}".format(dest_record.get_id()))
-    return dest_record
+# Load region-to-project mapping from the shared config file.
+# To add or retire a region, edit scripts/regions.json instead of this file.
+with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "regions.json")) as _f:
+    REGION_TO_PROJECT = json.load(_f)["regions"]
 
 
 def main():
@@ -203,39 +70,36 @@ def main():
     )
     print("Found copy app: {}".format(copy_app.get_id()))
 
-    # Verify the copy app actually supports the destination region
-    app_supported_regions = set(copy_app.describe()['regionalOptions'].keys())
-    if args.region not in app_supported_regions:
-        print("ERROR: Region '{}' is not supported by the '{}' app. "
-              "Supported regions: {}".format(
-                  args.region, COPY_FILE_APP_NAME,
-                  ", ".join(sorted(app_supported_regions))),
-              file=sys.stderr)
-        sys.exit(1)
-
     folder = "/releases/{}".format(args.version)
     language = args.language.capitalize()  # "Wdl" or "Cwl"
 
     # Find the source asset in the home region
-    home_proj = get_project(HOME_PROJECT_NAME)
+    home_proj = util.get_project(HOME_PROJECT_NAME)
     if home_proj is None:
         raise RuntimeError("Could not find home project '{}'".format(HOME_PROJECT_NAME))
     print("Home project: {} ({})".format(home_proj.name, home_proj.get_id()))
 
-    source_record = find_asset(home_proj, folder, language)
+    source_record = util.find_asset(home_proj, folder, language)
     if source_record is None:
         raise RuntimeError("No {} asset found in {}:{} — has the release been built?".format(
             language, HOME_PROJECT_NAME, folder))
     print("Source asset: {} ({})".format(source_record.name, source_record.get_id()))
 
-    # Find or create destination project
+    # Find destination project
     dest_proj_name = REGION_TO_PROJECT[args.region]
-    dest_proj = get_project(dest_proj_name)
+    dest_proj = util.get_project(dest_proj_name)
     if dest_proj is None:
         raise RuntimeError("Could not find destination project '{}'".format(dest_proj_name))
     print("Destination project: {} ({})".format(dest_proj.name, dest_proj.get_id()))
 
-    clone_asset(copy_app, source_record, dest_proj, folder, language)
+    # Idempotency check: skip if AssetBundle record already exists
+    existing = util.find_asset(dest_proj, folder, language)
+    if existing is not None:
+        print("Asset 'dx{}rt' already exists in {}:{} ({}). Nothing to do.".format(
+            language.upper(), dest_proj.name, folder, existing.get_id()))
+        return
+
+    util.clone_asset(copy_app, source_record, folder, [args.region], REGION_TO_PROJECT)
     print("Done.")
 
 

--- a/scripts/copy_asset_to_region.py
+++ b/scripts/copy_asset_to_region.py
@@ -27,7 +27,6 @@ import util
 
 COPY_FILE_APP_NAME = "dxwdl_copy"
 
-HOME_REGION = "aws:us-east-1"
 HOME_PROJECT_NAME = "dxCompiler"
 
 # Load region-to-project mapping from the shared config file.
@@ -59,8 +58,8 @@ def main():
         print("ERROR: Unknown region '{}'. Supported regions: {}".format(
             args.region, ", ".join(sorted(REGION_TO_PROJECT.keys()))))
         sys.exit(1)
-    if args.region == HOME_REGION:
-        print("ERROR: Destination region is the home region ({}). Nothing to copy.".format(HOME_REGION))
+    if args.region == util.HOME_REGION:
+        print("ERROR: Destination region is the home region ({}). Nothing to copy.".format(util.HOME_REGION))
         sys.exit(1)
 
     # Initialize copy app AFTER login (avoids module-level import-time failure)

--- a/scripts/copy_asset_to_region.py
+++ b/scripts/copy_asset_to_region.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Standalone script to copy a dxCompiler runtime asset from the home region
+(aws:us-east-1) into a specific destination region.
+
+Use this to backfill a region that was skipped during a release
+(e.g. because it was unavailable at release time).
+
+Usage:
+    python3 copy_asset_to_region.py \
+        --version 2.x.y \
+        --region aws:eu-west-2 \
+        --language wdl \
+        [--token <dx-auth-token>]
+
+If --token is not supplied the script uses the currently active dx login session.
+"""
+from __future__ import print_function
+
+import argparse
+import subprocess
+import sys
+import os
+
+import dxpy
+from dxpy.exceptions import DXJobFailureError
+
+here = os.path.dirname(sys.argv[0])
+top_dir = os.path.dirname(os.path.abspath(here))
+
+COPY_FILE_APP_NAME = "dxwdl_copy"
+URL_DURATION = 60 * 60 * 24  # 24 hours
+
+HOME_REGION = "aws:us-east-1"
+HOME_PROJECT_NAME = "dxCompiler"
+
+# Mapping from region name to destination project name
+REGION_TO_PROJECT = {
+    "aws:us-east-1":      "dxCompiler",
+    "aws:ap-southeast-2": "dxCompiler_Sydney",
+    "azure:westus":       "dxCompiler_Azure",
+    "azure:westeurope":   "dxCompiler_Amsterdam",
+    "aws:eu-central-1":   "dxCompiler_Berlin",
+    "aws:eu-west-2":      "dxCompiler_London",
+    "aws:eu-west-2-g":    "dxCompiler_Europe_London",
+    "azure:uksouth-ofh":  "dxCompiler_OFH_TRE_London",
+    "oci:us-ashburn-1":   "dxCompiler_Ashburn",
+}
+
+
+def get_project(project_name):
+    """Find a DNAnexus project by name."""
+    try:
+        project = dxpy.DXProject(project_name)
+        return project
+    except dxpy.DXError:
+        pass
+    results = list(dxpy.find_projects(name=project_name, return_handler=True, level="VIEW"))
+    if len(results) == 0:
+        return None
+    if len(results) == 1:
+        return results[0]
+    # Prefer owned projects
+    owned = [r for r in results if r.describe()["level"] == "ADMINISTER"]
+    if len(owned) == 1:
+        return owned[0]
+    raise RuntimeError("Found {} projects named '{}'".format(len(results), project_name))
+
+
+def find_asset(project, folder, language):
+    """Return the AssetBundle record for the given language in the given folder, or None."""
+    asset_name = "dx{}rt".format(language.upper())
+    assets = list(dxpy.search.find_data_objects(
+        classname="record",
+        project=project.get_id(),
+        name=asset_name,
+        folder=folder,
+        return_handler=True,
+    ))
+    if len(assets) == 0:
+        return None
+    if len(assets) == 1:
+        return assets[0]
+    raise RuntimeError("Found {} records named '{}' in {}:{}".format(
+        len(assets), asset_name, project.name, folder))
+
+
+def _wait_for_job(job):
+    """Block until job completes, printing timestamps every 60 s to keep CI alive."""
+    noise = subprocess.Popen(["/bin/bash", "-c", "while true; do sleep 60; date; done"])
+    try:
+        job.wait_on_done()
+    finally:
+        noise.kill()
+
+
+def clone_asset(copy_app, source_record, dest_proj, folder, language):
+    """
+    Clone the asset from source_record into dest_proj/folder using the dxwdl_copy app.
+    Returns the newly created AssetBundle record in the destination project.
+    """
+    asset_name = "dx{}rt".format(language.upper())
+
+    # Check if the asset already exists in the destination
+    existing = find_asset(dest_proj, folder, language)
+    if existing is not None:
+        print("Asset '{}' already exists in {}:{} ({}). Nothing to do.".format(
+            asset_name, dest_proj.name, folder, existing.get_id()))
+        return existing
+
+    # Get the underlying file from the source record
+    fid = source_record.get_details()['archiveFileId']['$dnanexus_link']
+    asset_file_name = dxpy.describe(fid)['name']
+
+    print("Generating pre-authenticated download URL for {} ...".format(asset_file_name))
+    url = dxpy.DXFile(fid).get_download_url(
+        preauthenticated=True,
+        project=dxpy.DXFile.NO_PROJECT_HINT,
+        duration=URL_DURATION,
+    )[0]
+
+    dest_proj.new_folder(folder, parents=True)
+    dest_region = dxpy.describe(dest_proj.get_id())['region']
+
+    print("Launching copy job in region {} (project: {} {}) ...".format(
+        dest_region, dest_proj.name, dest_proj.get_id()))
+    dxjob = copy_app.run(
+        app_input={"url": url, "folder": folder, "filename": asset_file_name},
+        name="copy {} to {}".format(asset_name, dest_region),
+        project=dest_proj.get_id(),
+        priority="high",
+    )
+    print("Copy job: {}".format(dxjob.get_id()))
+
+    print("Waiting for copy job to complete ...")
+    _wait_for_job(dxjob)
+    print("Copy job finished.")
+
+    # Find the uploaded file
+    results = list(dxpy.find_data_objects(
+        classname="file",
+        visibility="hidden",
+        name=asset_file_name,
+        project=dest_proj.get_id(),
+        folder=folder,
+    ))
+    file_ids = [p["id"] for p in results]
+    if len(file_ids) == 0:
+        raise RuntimeError("Copy job succeeded but no file found at {}:{}/{}".format(
+            dest_proj.get_id(), folder, asset_file_name))
+    if len(file_ids) > 1:
+        raise RuntimeError("Found {} files at {}:{}/{}, expected exactly one".format(
+            len(file_ids), dest_proj.get_id(), folder, asset_file_name))
+
+    # Create the AssetBundle record pointing at the copied file
+    asset_properties = source_record.get_properties()
+    asset_properties['cloned_from'] = source_record.get_id()
+
+    dest_record = dxpy.new_dxrecord(
+        name=source_record.name,
+        types=['AssetBundle'],
+        details={'archiveFileId': dxpy.dxlink(file_ids[0])},
+        properties=asset_properties,
+        project=dest_proj.get_id(),
+        folder=folder,
+        close=True,
+    )
+    print("Created AssetBundle record: {}".format(dest_record.get_id()))
+    return dest_record
+
+
+def main():
+    argparser = argparse.ArgumentParser(
+        description="Copy a dxCompiler runtime asset from the home region to a destination region"
+    )
+    argparser.add_argument("--version", required=True,
+                           help="dxCompiler release version (e.g. 2.11.0)")
+    argparser.add_argument("--region", required=True,
+                           help="Destination region (e.g. aws:eu-west-2)")
+    argparser.add_argument("--language", required=True, choices=["wdl", "cwl"],
+                           help="Runtime language asset to copy")
+    argparser.add_argument("--token",
+                           help="DNAnexus auth token. If omitted, uses the current dx session.")
+    args = argparser.parse_args()
+
+    # Authenticate
+    if args.token:
+        dxpy.set_security_context({"auth_token_type": "Bearer", "auth_token": args.token})
+
+    # Validate region
+    if args.region not in REGION_TO_PROJECT:
+        print("ERROR: Unknown region '{}'. Supported regions: {}".format(
+            args.region, ", ".join(sorted(REGION_TO_PROJECT.keys()))))
+        sys.exit(1)
+    if args.region == HOME_REGION:
+        print("ERROR: Destination region is the home region ({}). Nothing to copy.".format(HOME_REGION))
+        sys.exit(1)
+
+    # Initialize copy app AFTER login (avoids module-level import-time failure)
+    print("Looking up copy app '{}' ...".format(COPY_FILE_APP_NAME))
+    copy_app = dxpy.find_one_app(
+        zero_ok=False, more_ok=False, name=COPY_FILE_APP_NAME, return_handler=True
+    )
+    print("Found copy app: {}".format(copy_app.get_id()))
+
+    # Verify the copy app actually supports the destination region
+    app_supported_regions = set(copy_app.describe()['regionalOptions'].keys())
+    if args.region not in app_supported_regions:
+        print("ERROR: Region '{}' is not supported by the '{}' app. "
+              "Supported regions: {}".format(
+                  args.region, COPY_FILE_APP_NAME,
+                  ", ".join(sorted(app_supported_regions))),
+              file=sys.stderr)
+        sys.exit(1)
+
+    folder = "/releases/{}".format(args.version)
+    language = args.language.capitalize()  # "Wdl" or "Cwl"
+
+    # Find the source asset in the home region
+    home_proj = get_project(HOME_PROJECT_NAME)
+    if home_proj is None:
+        raise RuntimeError("Could not find home project '{}'".format(HOME_PROJECT_NAME))
+    print("Home project: {} ({})".format(home_proj.name, home_proj.get_id()))
+
+    source_record = find_asset(home_proj, folder, language)
+    if source_record is None:
+        raise RuntimeError("No {} asset found in {}:{} — has the release been built?".format(
+            language, HOME_PROJECT_NAME, folder))
+    print("Source asset: {} ({})".format(source_record.name, source_record.get_id()))
+
+    # Find or create destination project
+    dest_proj_name = REGION_TO_PROJECT[args.region]
+    dest_proj = get_project(dest_proj_name)
+    if dest_proj is None:
+        raise RuntimeError("Could not find destination project '{}'".format(dest_proj_name))
+    print("Destination project: {} ({})".format(dest_proj.name, dest_proj.get_id()))
+
+    clone_asset(copy_app, source_record, dest_proj, folder, language)
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/dxcompiler_copy/dxapp.json
+++ b/scripts/dxcompiler_copy/dxapp.json
@@ -116,7 +116,7 @@
     }
   },
   "details": {
-    "whatsNew": "* 0.2.1: Removed Bahrain AWS region aws:me-south-1 \n * 0.2.0: Update running environment to Ubuntu 24.04 \n * 0.1.0: Added new OCI Ashburn region \n * 0.0.7: Fixed instance types for Azure regions\n * 0.0.6: Added new Bahrain AWS region aws:me-south-1\n * 0.0.5: updated azure instances to v2 for OFH region\n * 0.0.3: Added new London OFH region\n * 0.0.2: Added new London region."
+    "whatsNew": "* 0.2.1: Removed Bahrain AWS region aws:me-south-1; added scripts/copy_asset_to_region.py for backfilling a skipped region after recovery \n * 0.2.0: Update running environment to Ubuntu 24.04 \n * 0.1.0: Added new OCI Ashburn region \n * 0.0.7: Fixed instance types for Azure regions\n * 0.0.6: Added new Bahrain AWS region aws:me-south-1\n * 0.0.5: updated azure instances to v2 for OFH region\n * 0.0.3: Added new London OFH region\n * 0.0.2: Added new London region."
   },
   "access": {
     "network": [

--- a/scripts/multi_region_tests.py
+++ b/scripts/multi_region_tests.py
@@ -21,29 +21,13 @@ here = os.path.dirname(sys.argv[0])
 top_dir = os.path.dirname(os.path.abspath(here))
 test_dir = os.path.join(os.path.abspath(top_dir), "test")
 
-projects = ["dxCompiler",
-            "dxCompiler_Sydney",
-            "dxCompiler_Azure",
-            "dxCompiler_Amsterdam",
-            "dxCompiler_Berlin",
-            "dxCompiler_London",
-            "dxCompiler_Europe_London",
-            "dxCompiler_OFH_TRE_London",
-            # "dxCompiler_Bahrain",  # Bahrain region no longer supported
-            "dxCompiler_Ashburn"]
+# Load region-to-project mapping from the shared config file.
+# To add or retire a region, edit scripts/regions.json instead of this file.
+with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "regions.json")) as _f:
+    REGION_TO_PROJECT = json.load(_f)["regions"]
 
-# Mapping from DNAnexus region name to project name (mirrors RELEASE_DICT in build_release.py)
-REGION_TO_PROJECT = {
-    "aws:us-east-1":      "dxCompiler",
-    "aws:ap-southeast-2": "dxCompiler_Sydney",
-    "azure:westus":       "dxCompiler_Azure",
-    "azure:westeurope":   "dxCompiler_Amsterdam",
-    "aws:eu-central-1":   "dxCompiler_Berlin",
-    "aws:eu-west-2":      "dxCompiler_London",
-    "aws:eu-west-2-g":    "dxCompiler_Europe_London",
-    "azure:uksouth-ofh":  "dxCompiler_OFH_TRE_London",
-    "oci:us-ashburn-1":   "dxCompiler_Ashburn",
-}
+# Ordered list of project names derived from the mapping
+projects = list(REGION_TO_PROJECT.values())
 
 target_folder = "/release_test"
 

--- a/scripts/multi_region_tests.py
+++ b/scripts/multi_region_tests.py
@@ -32,6 +32,19 @@ projects = ["dxCompiler",
             # "dxCompiler_Bahrain",  # Bahrain region no longer supported
             "dxCompiler_Ashburn"]
 
+# Mapping from DNAnexus region name to project name (mirrors RELEASE_DICT in build_release.py)
+REGION_TO_PROJECT = {
+    "aws:us-east-1":      "dxCompiler",
+    "aws:ap-southeast-2": "dxCompiler_Sydney",
+    "azure:westus":       "dxCompiler_Azure",
+    "azure:westeurope":   "dxCompiler_Amsterdam",
+    "aws:eu-central-1":   "dxCompiler_Berlin",
+    "aws:eu-west-2":      "dxCompiler_London",
+    "aws:eu-west-2-g":    "dxCompiler_Europe_London",
+    "azure:uksouth-ofh":  "dxCompiler_OFH_TRE_London",
+    "oci:us-ashburn-1":   "dxCompiler_Ashburn",
+}
+
 target_folder = "/release_test"
 
 def wait_for_completion(test_exec_objs):
@@ -77,7 +90,34 @@ def main():
     argparser = argparse.ArgumentParser(description="Run compiler tests on the platform")
     argparser.add_argument("--compile-only", help="Only compile the workflows, don't run them",
                            action="store_true", default=False)
+    argparser.add_argument("--skip-regions",
+                           help="Comma-separated regions to skip testing (e.g. aws:eu-west-2). "
+                                "Uses the same region names as --skip-clone-regions in build_release.py.",
+                           default="")
     args = argparser.parse_args()
+
+    # strip whitespace around each entry to tolerate "aws:eu-west-2, azure:westeurope"
+    skip_regions = (
+        set(r.strip() for r in args.skip_regions.split(",") if r.strip())
+        if args.skip_regions else set()
+    )
+
+    # Validate region names against known mapping
+    if skip_regions:
+        unknown = skip_regions - set(REGION_TO_PROJECT.keys())
+        if unknown:
+            print("ERROR: Unknown region(s) in --skip-regions: {}. "
+                  "Known regions: {}".format(", ".join(sorted(unknown)),
+                                             ", ".join(sorted(REGION_TO_PROJECT.keys()))))
+            sys.exit(1)
+
+    # Build a reverse map: project_name -> region, to filter out skipped regions
+    project_to_region = {v: k for k, v in REGION_TO_PROJECT.items()}
+    active_projects = [p for p in projects if project_to_region.get(p) not in skip_regions]
+
+    if skip_regions:
+        skipped = [p for p in projects if p not in active_projects]
+        print("Skipping projects for regions {}: {}".format(skip_regions, skipped))
 
     version_id = util.get_version_id(top_dir)
     wdl_source_file = os.path.join(test_dir, "multi_region/trivial.wdl")
@@ -85,7 +125,7 @@ def main():
     test_exec_objs=[]
 
     # build version of the applet on all regions
-    for proj_name in projects:
+    for proj_name in active_projects:
         dx_proj = util.get_project(proj_name)
         if dx_proj is None:
             raise RuntimeError("Could not find project {}".format(proj_name))

--- a/scripts/regions.json
+++ b/scripts/regions.json
@@ -14,7 +14,7 @@
   "retired_regions": {
     "aws:me-south-1": {
       "project": "dxCompiler_Bahrain",
-      "reason": "Region no longer supported by DNAnexus"
+      "reason": "Region is currently inaccessible"
     }
   }
 }

--- a/scripts/regions.json
+++ b/scripts/regions.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Single source of truth for region-to-project mapping. To add a region, add an entry here and create the corresponding DNAnexus project. To retire a region, move its entry to 'retired_regions' with a reason.",
+  "regions": {
+    "aws:us-east-1":      "dxCompiler",
+    "aws:ap-southeast-2": "dxCompiler_Sydney",
+    "azure:westus":       "dxCompiler_Azure",
+    "azure:westeurope":   "dxCompiler_Amsterdam",
+    "aws:eu-central-1":   "dxCompiler_Berlin",
+    "aws:eu-west-2":      "dxCompiler_London",
+    "aws:eu-west-2-g":    "dxCompiler_Europe_London",
+    "azure:uksouth-ofh":  "dxCompiler_OFH_TRE_London",
+    "oci:us-ashburn-1":   "dxCompiler_Ashburn"
+  },
+  "retired_regions": {
+    "aws:me-south-1": {
+      "project": "dxCompiler_Bahrain",
+      "reason": "Region no longer supported by DNAnexus"
+    }
+  }
+}

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -497,6 +497,129 @@ def build(
     return asset_descs
 
 
+_CLONE_URL_DURATION = 60 * 60 * 24  # 24 hours
+
+
+def wait_for_completion(jobs):
+    """Block until all jobs complete. Prints timestamps every 60 s to prevent CI inactivity timeout."""
+    print("awaiting completion ...")
+    noise = subprocess.Popen(["/bin/bash", "-c", "while true; do sleep 60; date; done"])
+    success = True
+    try:
+        for j in jobs:
+            try:
+                j.wait_on_done()
+            except dxpy.exceptions.DXJobFailureError:
+                print("job {} failed".format(j.get_id()))
+                success = False
+    finally:
+        noise.kill()
+    print("done")
+    return success
+
+
+def _launch_copy_job(copy_app, region, dest_proj_id, asset_file_name, dest_folder, url):
+    """Launch the dxwdl_copy app job in the destination region."""
+    dxjob = copy_app.run(
+        app_input={"url": url, "folder": dest_folder, "filename": asset_file_name},
+        name="copy to region {}".format(region),
+        project=dest_proj_id,
+        priority="high",  # high priority needed for some regions (e.g. OFH)
+    )
+    print("{region}: {job_id}".format(region=region, job_id=dxjob.get_id()), file=sys.stderr)
+    return dxjob
+
+
+def clone_asset(copy_app, record, folder, regions, project_dict, num_retries=3):
+    """
+    Clone an AssetBundle record from its home region into each of the given destination regions.
+
+    copy_app:     initialized DXApp handle for the dxwdl_copy app (must be obtained after login)
+    record:       source AssetBundle DXRecord in the home region
+    folder:       target folder path (e.g. /releases/2.11.0)
+    regions:      iterable of region names to clone into
+    project_dict: mapping from region name to DNAnexus project name
+    num_retries:  number of copy attempts before giving up (default 3)
+    """
+    fid = record.get_details()['archiveFileId']['$dnanexus_link']
+    curr_region = dxpy.describe(record.project)['region']
+
+    # Do not clone back into the source region
+    regions = set(regions) - {curr_region}
+    if not regions:
+        return
+
+    # Validate the copy app supports all requested regions
+    app_supported_regions = set(copy_app.describe()['regionalOptions'].keys())
+    unsupported = regions - app_supported_regions
+    if unsupported:
+        print('Currently no support for the following region(s): [{}]'.format(
+            ', '.join(unsupported)), file=sys.stderr)
+        sys.exit(1)
+
+    asset_file_name = dxpy.describe(fid)['name']
+    url = dxpy.DXFile(fid).get_download_url(
+        preauthenticated=True,
+        project=dxpy.DXFile.NO_PROJECT_HINT,
+        duration=_CLONE_URL_DURATION,
+    )[0]
+
+    # Set up destination projects and folders
+    region2projid = {}
+    for region in regions:
+        dest_proj = get_project(project_dict[region])
+        dest_proj.new_folder(folder, parents=True)
+        region2projid[region] = dest_proj.get_id()
+    print(region2projid)
+
+    # Fire copy jobs (all regions in parallel) with retries
+    for _ in range(num_retries):
+        jobs = []
+        for region in regions:
+            dest_proj_id = region2projid[region]
+            results = list(dxpy.find_data_objects(
+                classname="file", visibility="hidden",
+                name=asset_file_name, project=dest_proj_id, folder=folder,
+            ))
+            file_ids = [p["id"] for p in results]
+            nfiles = len(file_ids)
+            if nfiles == 1:
+                continue  # file already present, skip
+            if nfiles > 1:
+                print("cleanup in {}, found {} files instead of 0/1".format(dest_proj_id, nfiles))
+                dxpy.DXProject(dest_proj_id).remove_objects(file_ids)
+            jobs.append(_launch_copy_job(copy_app, region, dest_proj_id, asset_file_name, folder, url))
+        if wait_for_completion(jobs):
+            break
+
+    # Create AssetBundle records pointing at the copied files
+    for region in regions:
+        dest_proj_id = region2projid[region]
+        info("Cloning asset into {}, project: {}, asset file name: {}".format(
+            region, dest_proj_id, asset_file_name))
+        results = list(dxpy.find_data_objects(
+            classname="file", visibility="hidden",
+            name=asset_file_name, project=dest_proj_id, folder=folder,
+        ))
+        file_ids = [p["id"] for p in results]
+        if len(file_ids) == 0:
+            raise RuntimeError("Found no files {}:{}/{}".format(dest_proj_id, folder, asset_file_name))
+        if len(file_ids) > 1:
+            raise RuntimeError("Found {} files {}:{}/{}, instead of just one".format(
+                len(file_ids), dest_proj_id, folder, asset_file_name))
+        asset_properties = record.get_properties()
+        asset_properties['cloned_from'] = record.get_id()
+        dxpy.new_dxrecord(
+            name=record.name,
+            types=['AssetBundle'],
+            details={'archiveFileId': dxpy.dxlink(file_ids[0])},
+            properties=asset_properties,
+            project=dest_proj_id,
+            folder=folder,
+            close=True,
+        )
+
+
 # Read a JSON file
 def read_json_file(path):
     with open(path, "r") as fd:

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -24,6 +24,8 @@ max_num_retries = 5
 # - asset name = "dx{}rt".format(lang.upper())
 languages = ["Wdl", "Cwl"]
 
+HOME_REGION = "aws:us-east-1"
+
 DEFAULT_INSTANCE_TYPE = "mem1_ssd1_v2_x4"
 GIT_REVISION = subprocess.check_output(
     ["git", "describe", "--always", "--dirty", "--tags"]


### PR DESCRIPTION
https://jira.internal.dnanexus.com/browse/APPS-3990

Because of the UKB incident, we can't copy asset from main region to the London Region. Temporarily, skip releasing London region DxComplier for now.

Here is the approach:

1. Add skip-clone-regionsas aworkflow_dispatchinput torelease.yml— allows skipping the asset clone step for a specific region at runtime without any code changes. The region is still included in the JAR's baked-indxCompiler_runtime.conf, so no JAR rebuild is needed when the region recovers.

2. Add a newcopy_asset_to_region.yml {}GHA workflow — allows manually backfilling the missing asset into a recovered region for any previously released version. When aws:eu-west-2 recovers, just trigger this workflow with the target region and version. No code changes required.

For future releases, no code changes are needed either — simply leave skip-clone-regions empty in the release workflow to clone assets to all regions as normal.