### PR TITLE
DOCS-2856 Fix dxCompiler help string typos

### DIFF
--- a/compiler/src/main/scala/dxCompiler/Main.scala
+++ b/compiler/src/main/scala/dxCompiler/Main.scala
@@ -829,7 +829,7 @@ object Main {
         |  
         |  describe <DxWorkflow ID>
         |    Generate the JSON execution tree for a given DNAnexus workflow ID.
-        |    The workflow needs to be have been previously compiled by dxCompiler.
+        |    The workflow needs to have been previously compiled by dxCompiler.
         |    options
         |      -pretty                Print exec tree in "pretty" text format instead of JSON.
         |
@@ -850,7 +850,7 @@ object Main {
         |                             that perform runtime evaluation of instance type
         |                             requirements. This instance type is also used when 
         |                             the '-instanceTypeSelection dynamic' option is set.
-        |                             This value is overriden by any defaults set in set in the 
+        |                             This value is overridden by any defaults set in the 
         |                             JSON file specified by '-extras'.
         |      -destination <string>  Full platform path (project:/folder).
         |      -execTree [json,pretty]    


### PR DESCRIPTION
## Description

Fix two typo/grammar issues in the user-facing dxCompiler CLI help string in `Main.scala`:

- Change `needs to be have been` to `needs to have been`.
- Change `overriden by any defaults set in set in the` to `overridden by any defaults set in the`.
